### PR TITLE
Fix dimensions block for response time autoscaling

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,4 +13,6 @@ jobs:
       run: |
         curl https://pre-commit.com/install-local.py | python3 -
         curl -L "$(curl -s https://api.github.com/repos/segmentio/terraform-docs/releases/latest | grep -o -E "https://.+?-linux-amd64")" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
+        /home/runner/bin/pre-commit --version
+        terraform-docs --version
         /home/runner/bin/pre-commit run -a

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,6 @@ repos:
     - id: terraform_fmt
     - id: terraform_docs
 - repo: git://github.com/pre-commit/pre-commit-hooks
-  rev: v2.4.0
+  rev: v2.5.0
   hooks:
     - id: check-merge-conflict

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.20.0
+  rev: v1.29.0
   hooks:
     - id: terraform_fmt
     - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -45,15 +45,21 @@ This module uses Semver.
 `z` shall change when there's documentation updates, minor fixes, etc.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| capacity\_providers | List of short names or full Amazon Resource Names \(ARNs\) of one or more capacity providers to associate with the cluster. Valid values also include `FARGATE` and `FARGATE\_SPOT`. | list(string) | `"null"` | no |
-| default\_capacity\_provider\_strategy | The capacity provider strategy to use by default for the cluster. Can be one or more. List of map with corresponding items in docs. \[Terraform Docs\]\(https://www.terraform.io/docs/providers/aws/r/ecs\_cluster.html#default\_capacity\_provider\_strategy\) | list(any) | `[]` | no |
-| name | Cluster name. | string | n/a | yes |
-| settings | List of maps with cluster settings. For example, this can be used to enable CloudWatch Container Insights for a cluster. \[Terraform Docs\]\(https://www.terraform.io/docs/providers/aws/r/ecs\_cluster.html#setting\) | list(any) | `[]` | no |
-| tags | Key-value mapping of resource tags. | map(string) | `{}` | no |
+|------|-------------|------|---------|:-----:|
+| capacity\_providers | List of short names or full Amazon Resource Names (ARNs) of one or more capacity providers to associate with the cluster. Valid values also include `FARGATE` and `FARGATE_SPOT`. | `list(string)` | n/a | yes |
+| default\_capacity\_provider\_strategy | The capacity provider strategy to use by default for the cluster. Can be one or more. List of map with corresponding items in docs. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_cluster.html#default_capacity_provider_strategy) | `list(any)` | `[]` | no |
+| name | Cluster name. | `any` | n/a | yes |
+| settings | List of maps with cluster settings. For example, this can be used to enable CloudWatch Container Insights for a cluster. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_cluster.html#setting) | `list(any)` | `[]` | no |
+| tags | Key-value mapping of resource tags. | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ This module uses Semver.
 `z` shall change when there's documentation updates, minor fixes, etc.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
 ## Providers
 
 | Name | Version |
@@ -54,8 +58,8 @@ This module uses Semver.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
-| capacity\_providers | List of short names or full Amazon Resource Names (ARNs) of one or more capacity providers to associate with the cluster. Valid values also include `FARGATE` and `FARGATE_SPOT`. | `list(string)` | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| capacity\_providers | List of short names or full Amazon Resource Names (ARNs) of one or more capacity providers to associate with the cluster. Valid values also include `FARGATE` and `FARGATE_SPOT`. | `list(string)` | `null` | no |
 | default\_capacity\_provider\_strategy | The capacity provider strategy to use by default for the cluster. Can be one or more. List of map with corresponding items in docs. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_cluster.html#default_capacity_provider_strategy) | `list(any)` | `[]` | no |
 | name | Cluster name. | `any` | n/a | yes |
 | settings | List of maps with cluster settings. For example, this can be used to enable CloudWatch Container Insights for a cluster. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_cluster.html#setting) | `list(any)` | `[]` | no |

--- a/examples/complete-ecs/README.md
+++ b/examples/complete-ecs/README.md
@@ -27,13 +27,19 @@ $ terraform apply
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | ~> 2 |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| availability\_zones | Override automatic detection of availability zones | list(string) | `[]` | no |
-| enable\_ipv6 | Enable IPv6? | bool | `"true"` | no |
-| instance\_profile\_arn | Instance Profile to use for EC2 to join to ECS Cluster. See `modules/iam/ecs-instance-profile` | string | n/a | yes |
+|------|-------------|------|---------|:-----:|
+| availability\_zones | Override automatic detection of availability zones | `list(string)` | `[]` | no |
+| enable\_ipv6 | Enable IPv6? | `bool` | `true` | no |
+| instance\_profile\_arn | Instance Profile to use for EC2 to join to ECS Cluster. See `modules/iam/ecs-instance-profile` | `string` | n/a | yes |
 
 ## Outputs
 

--- a/examples/complete-ecs/README.md
+++ b/examples/complete-ecs/README.md
@@ -27,6 +27,12 @@ $ terraform apply
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| aws | ~> 2 |
+
 ## Providers
 
 | Name | Version |
@@ -36,7 +42,7 @@ $ terraform apply
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | availability\_zones | Override automatic detection of availability zones | `list(string)` | `[]` | no |
 | enable\_ipv6 | Enable IPv6? | `bool` | `true` | no |
 | instance\_profile\_arn | Instance Profile to use for EC2 to join to ECS Cluster. See `modules/iam/ecs-instance-profile` | `string` | n/a | yes |

--- a/examples/easy/ec2-alb/README.md
+++ b/examples/easy/ec2-alb/README.md
@@ -20,13 +20,19 @@ To test that it's working:
 1. Nginx hello world screen should appear
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | ~> 2 |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| availability\_zones | Override automatic detection of availability zones | list(string) | `[]` | no |
-| enable\_ipv6 | Enable IPv6? | bool | `"true"` | no |
-| instance\_profile\_arn | Instance Profile to use for EC2 to join to ECS Cluster. See `modules/iam/ecs-instance-profile` | string | n/a | yes |
+|------|-------------|------|---------|:-----:|
+| availability\_zones | Override automatic detection of availability zones | `list(string)` | `[]` | no |
+| enable\_ipv6 | Enable IPv6? | `bool` | `true` | no |
+| instance\_profile\_arn | Instance Profile to use for EC2 to join to ECS Cluster. See `modules/iam/ecs-instance-profile` | `string` | n/a | yes |
 
 ## Outputs
 

--- a/examples/easy/ec2-alb/README.md
+++ b/examples/easy/ec2-alb/README.md
@@ -20,6 +20,12 @@ To test that it's working:
 1. Nginx hello world screen should appear
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| aws | ~> 2 |
+
 ## Providers
 
 | Name | Version |
@@ -29,7 +35,7 @@ To test that it's working:
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | availability\_zones | Override automatic detection of availability zones | `list(string)` | `[]` | no |
 | enable\_ipv6 | Enable IPv6? | `bool` | `true` | no |
 | instance\_profile\_arn | Instance Profile to use for EC2 to join to ECS Cluster. See `modules/iam/ecs-instance-profile` | `string` | n/a | yes |

--- a/examples/easy/ec2/README.md
+++ b/examples/easy/ec2/README.md
@@ -26,6 +26,12 @@ $ terraform apply
 
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| aws | ~> 2 |
+
 ## Providers
 
 | Name | Version |
@@ -35,7 +41,7 @@ $ terraform apply
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | availability\_zones | Override automatic detection of availability zones | `list(string)` | `[]` | no |
 | enable\_ipv6 | Enable IPv6? | `bool` | `true` | no |
 | instance\_profile\_arn | Instance Profile to use for EC2 to join to ECS Cluster. See `modules/iam/ecs-instance-profile` | `string` | n/a | yes |

--- a/examples/easy/ec2/README.md
+++ b/examples/easy/ec2/README.md
@@ -26,13 +26,23 @@ $ terraform apply
 
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | ~> 2 |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| availability\_zones | Override automatic detection of availability zones | list(string) | `[]` | no |
-| enable\_ipv6 | Enable IPv6? | bool | `"true"` | no |
-| instance\_profile\_arn | Instance Profile to use for EC2 to join to ECS Cluster. See `modules/iam/ecs-instance-profile` | string | n/a | yes |
+|------|-------------|------|---------|:-----:|
+| availability\_zones | Override automatic detection of availability zones | `list(string)` | `[]` | no |
+| enable\_ipv6 | Enable IPv6? | `bool` | `true` | no |
+| instance\_profile\_arn | Instance Profile to use for EC2 to join to ECS Cluster. See `modules/iam/ecs-instance-profile` | `string` | n/a | yes |
+
+## Outputs
+
+No output.
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/examples/easy/fargate-alb/README.md
+++ b/examples/easy/fargate-alb/README.md
@@ -27,6 +27,12 @@ $ terraform apply
 
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| aws | ~> 2 |
+
 ## Providers
 
 | Name | Version |
@@ -36,7 +42,7 @@ $ terraform apply
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | availability\_zones | Override automatic detection of availability zones | `list(string)` | `[]` | no |
 | enable\_ipv6 | Enable IPv6? | `bool` | `true` | no |
 

--- a/examples/easy/fargate-alb/README.md
+++ b/examples/easy/fargate-alb/README.md
@@ -27,12 +27,18 @@ $ terraform apply
 
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | ~> 2 |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| availability\_zones | Override automatic detection of availability zones | list(string) | `[]` | no |
-| enable\_ipv6 | Enable IPv6? | bool | `"true"` | no |
+|------|-------------|------|---------|:-----:|
+| availability\_zones | Override automatic detection of availability zones | `list(string)` | `[]` | no |
+| enable\_ipv6 | Enable IPv6? | `bool` | `true` | no |
 
 ## Outputs
 

--- a/examples/easy/fargate-spot/README.md
+++ b/examples/easy/fargate-spot/README.md
@@ -32,6 +32,16 @@ $ terraform apply
 
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | ~> 2 |
+
+## Inputs
+
+No input.
+
 ## Outputs
 
 | Name | Description |

--- a/examples/easy/fargate-spot/README.md
+++ b/examples/easy/fargate-spot/README.md
@@ -32,6 +32,12 @@ $ terraform apply
 
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| aws | ~> 2 |
+
 ## Providers
 
 | Name | Version |

--- a/examples/easy/fargate/README.md
+++ b/examples/easy/fargate/README.md
@@ -25,6 +25,12 @@ $ terraform apply
 
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| aws | ~> 2 |
+
 ## Providers
 
 | Name | Version |

--- a/examples/easy/fargate/README.md
+++ b/examples/easy/fargate/README.md
@@ -25,6 +25,16 @@ $ terraform apply
 
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | ~> 2 |
+
+## Inputs
+
+No input.
+
 ## Outputs
 
 | Name | Description |

--- a/modules/autoscaling/alb-target-tracking/target-requests-count/README.md
+++ b/modules/autoscaling/alb-target-tracking/target-requests-count/README.md
@@ -59,6 +59,10 @@ module "ecs_service_scaling" {
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
 ## Providers
 
 | Name | Version |
@@ -68,7 +72,7 @@ module "ecs_service_scaling" {
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | alb\_arn\_suffix | ARN Suffix (not full ARN) of the Application Load Balancer for use with CloudWatch. Output attribute from LB resource: `arn_suffix` | `string` | n/a | yes |
 | disable\_scale\_in | Disable scale-in action, defaults to false | `bool` | `false` | no |
 | name | Name of the ECS Policy created, will appear in Auto Scaling under Service in ECS | `string` | n/a | yes |

--- a/modules/autoscaling/alb-target-tracking/target-requests-count/README.md
+++ b/modules/autoscaling/alb-target-tracking/target-requests-count/README.md
@@ -59,18 +59,24 @@ module "ecs_service_scaling" {
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| alb\_arn\_suffix | ARN Suffix \(not full ARN\) of the Application Load Balancer for use with CloudWatch. Output attribute from LB resource: `arn\_suffix` | string | n/a | yes |
-| disable\_scale\_in | Disable scale-in action, defaults to false | bool | `"false"` | no |
-| name | Name of the ECS Policy created, will appear in Auto Scaling under Service in ECS | string | n/a | yes |
-| scalable\_target\_resource\_id | Scalable target resource id, either from resource `aws\_appautoscaling\_target` or from `core/ecs-autoscaling-target` module | string | n/a | yes |
-| scale\_in\_cooldown | Time between scale in action | number | `"300"` | no |
-| scale\_out\_cooldown | Time between scale out action | number | `"300"` | no |
-| target\_group\_arn\_suffix | ALB Target Group ARN Suffix \(not full ARN\) for use with CloudWatch. Output attribute from Target Group resource: `arn\_suffix` | string | n/a | yes |
-| target\_value | Requests per target in target group metrics to trigger scaling activity | number | n/a | yes |
+|------|-------------|------|---------|:-----:|
+| alb\_arn\_suffix | ARN Suffix (not full ARN) of the Application Load Balancer for use with CloudWatch. Output attribute from LB resource: `arn_suffix` | `string` | n/a | yes |
+| disable\_scale\_in | Disable scale-in action, defaults to false | `bool` | `false` | no |
+| name | Name of the ECS Policy created, will appear in Auto Scaling under Service in ECS | `string` | n/a | yes |
+| scalable\_target\_resource\_id | Scalable target resource id, either from resource `aws_appautoscaling_target` or from `core/ecs-autoscaling-target` module | `string` | n/a | yes |
+| scale\_in\_cooldown | Time between scale in action | `number` | `300` | no |
+| scale\_out\_cooldown | Time between scale out action | `number` | `300` | no |
+| target\_group\_arn\_suffix | ALB Target Group ARN Suffix (not full ARN) for use with CloudWatch. Output attribute from Target Group resource: `arn_suffix` | `string` | n/a | yes |
+| target\_value | Requests per target in target group metrics to trigger scaling activity | `number` | n/a | yes |
 
 ## Outputs
 

--- a/modules/autoscaling/alb-target-tracking/target-response-time/README.md
+++ b/modules/autoscaling/alb-target-tracking/target-response-time/README.md
@@ -60,20 +60,26 @@ module "ecs_service_scaling" {
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| alb\_arn\_suffix | ARN Suffix \(not full ARN\) of the Application Load Balancer for use with CloudWatch. Output attribute from LB resource: `arn\_suffix` | string | n/a | yes |
-| disable\_scale\_in | Disable scale-in action, defaults to false | bool | `"false"` | no |
-| name | Name of the ECS Policy created, will appear in Auto Scaling under Service in ECS | string | n/a | yes |
-| scalable\_target\_resource\_id | Scalable target resource id, either from resource `aws\_appautoscaling\_target` or from `core/ecs-autoscaling-target` module | string | n/a | yes |
-| scale\_in\_cooldown | Time between scale in action | number | `"300"` | no |
-| scale\_out\_cooldown | Time between scale out action | number | `"300"` | no |
-| statistic | Statistic to use. Valid value one of \[Average, Minimum, Maximum, SampleCount, Sum\] | string | `"Average"` | no |
-| target\_group\_arn\_suffix | ALB Target Group ARN Suffix \(not full ARN\) for use with CloudWatch. Output attribute from Target Group resource: `arn\_suffix` | string | n/a | yes |
-| target\_value | Response time per target in target group metrics to trigger scaling activity \(in seconds\) | number | n/a | yes |
-| units | Units to use in monitoring, valid values are \[Seconds, Microseconds, Milliseconds\] | string | `"Seconds"` | no |
+|------|-------------|------|---------|:-----:|
+| alb\_arn\_suffix | ARN Suffix (not full ARN) of the Application Load Balancer for use with CloudWatch. Output attribute from LB resource: `arn_suffix` | `string` | n/a | yes |
+| disable\_scale\_in | Disable scale-in action, defaults to false | `bool` | `false` | no |
+| name | Name of the ECS Policy created, will appear in Auto Scaling under Service in ECS | `string` | n/a | yes |
+| scalable\_target\_resource\_id | Scalable target resource id, either from resource `aws_appautoscaling_target` or from `core/ecs-autoscaling-target` module | `string` | n/a | yes |
+| scale\_in\_cooldown | Time between scale in action | `number` | `300` | no |
+| scale\_out\_cooldown | Time between scale out action | `number` | `300` | no |
+| statistic | Statistic to use. Valid value one of [Average, Minimum, Maximum, SampleCount, Sum] | `string` | `"Average"` | no |
+| target\_group\_arn\_suffix | ALB Target Group ARN Suffix (not full ARN) for use with CloudWatch. Output attribute from Target Group resource: `arn_suffix` | `string` | n/a | yes |
+| target\_value | Response time per target in target group metrics to trigger scaling activity (in seconds) | `number` | n/a | yes |
+| units | Units to use in monitoring, valid values are [Seconds, Microseconds, Milliseconds] | `string` | `"Seconds"` | no |
 
 ## Outputs
 

--- a/modules/autoscaling/alb-target-tracking/target-response-time/README.md
+++ b/modules/autoscaling/alb-target-tracking/target-response-time/README.md
@@ -60,6 +60,10 @@ module "ecs_service_scaling" {
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
 ## Providers
 
 | Name | Version |
@@ -69,7 +73,7 @@ module "ecs_service_scaling" {
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | alb\_arn\_suffix | ARN Suffix (not full ARN) of the Application Load Balancer for use with CloudWatch. Output attribute from LB resource: `arn_suffix` | `string` | n/a | yes |
 | disable\_scale\_in | Disable scale-in action, defaults to false | `bool` | `false` | no |
 | name | Name of the ECS Policy created, will appear in Auto Scaling under Service in ECS | `string` | n/a | yes |

--- a/modules/autoscaling/alb-target-tracking/target-response-time/main.tf
+++ b/modules/autoscaling/alb-target-tracking/target-response-time/main.tf
@@ -16,16 +16,14 @@ resource "aws_appautoscaling_policy" "ecs_policy" {
       namespace   = "AWS/ApplicationELB"
       statistic   = var.statistic
 
-      dimensions = [
-        {
-          name  = "LoadBalancer"
-          value = var.alb_arn_suffix
-        },
-        {
-          name  = "TargetGroup"
-          value = var.target_group_arn_suffix
-        },
-      ]
+      dimensions {
+        name  = "LoadBalancer"
+        value = var.alb_arn_suffix
+      }
+      dimensions {
+        name  = "TargetGroup"
+        value = var.target_group_arn_suffix
+      }
 
       unit = var.units
     }

--- a/modules/autoscaling/asg-target-tracking/ecs-reservation/README.md
+++ b/modules/autoscaling/asg-target-tracking/ecs-reservation/README.md
@@ -74,20 +74,26 @@ module "asg_scaling" {
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| autoscaling\_group\_name | Autoscaling Group to apply the policy | string | n/a | yes |
-| cpu\_statistics | Statistics to use: \[Maximum, SampleCount, Sum, Minimum, Average\]. Note that resolution used in alarm generated is 1 minute. | string | `"Average"` | no |
-| cpu\_threshold | Keep the ECS Cluster CPU Reservation around this value. Value is in percentage \(0..100\). Must be specified if cpu based autoscaling is enabled. | number | `"null"` | no |
-| disable\_scale\_in | Indicates whether scale in by the target tracking policy is disabled. | bool | `"false"` | no |
-| ecs\_cluster\_name | Name \(not ARN\) of ECS Cluster that the autoscaling group is attached to | string | n/a | yes |
-| enable\_cpu\_based\_autoscaling | Enable Autoscaling based on ECS Cluster CPU Reservation | bool | `"false"` | no |
-| enable\_memory\_based\_autoscaling | Enable Autoscaling based on ECS Cluster Memory Reservation | bool | `"false"` | no |
-| memory\_statistics | Statistics to use: \[Maximum, SampleCount, Sum, Minimum, Average\]. Note that resolution used in alarm generated is 1 minute. | string | `"Average"` | no |
-| memory\_threshold | Keep the ECS Cluster Memory Reservation around this value. Value is in percentage \(0..100\). Must be specified if memory based autoscaling is enabled. | number | `"null"` | no |
-| name | Name prefix of the Autoscaling Policy | string | n/a | yes |
+|------|-------------|------|---------|:-----:|
+| autoscaling\_group\_name | Autoscaling Group to apply the policy | `string` | n/a | yes |
+| cpu\_statistics | Statistics to use: [Maximum, SampleCount, Sum, Minimum, Average]. Note that resolution used in alarm generated is 1 minute. | `string` | `"Average"` | no |
+| cpu\_threshold | Keep the ECS Cluster CPU Reservation around this value. Value is in percentage (0..100). Must be specified if cpu based autoscaling is enabled. | `number` | n/a | yes |
+| disable\_scale\_in | Indicates whether scale in by the target tracking policy is disabled. | `bool` | `false` | no |
+| ecs\_cluster\_name | Name (not ARN) of ECS Cluster that the autoscaling group is attached to | `string` | n/a | yes |
+| enable\_cpu\_based\_autoscaling | Enable Autoscaling based on ECS Cluster CPU Reservation | `bool` | `false` | no |
+| enable\_memory\_based\_autoscaling | Enable Autoscaling based on ECS Cluster Memory Reservation | `bool` | `false` | no |
+| memory\_statistics | Statistics to use: [Maximum, SampleCount, Sum, Minimum, Average]. Note that resolution used in alarm generated is 1 minute. | `string` | `"Average"` | no |
+| memory\_threshold | Keep the ECS Cluster Memory Reservation around this value. Value is in percentage (0..100). Must be specified if memory based autoscaling is enabled. | `number` | n/a | yes |
+| name | Name prefix of the Autoscaling Policy | `string` | n/a | yes |
 
 ## Outputs
 

--- a/modules/autoscaling/asg-target-tracking/ecs-reservation/README.md
+++ b/modules/autoscaling/asg-target-tracking/ecs-reservation/README.md
@@ -74,6 +74,10 @@ module "asg_scaling" {
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
 ## Providers
 
 | Name | Version |
@@ -83,16 +87,16 @@ module "asg_scaling" {
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | autoscaling\_group\_name | Autoscaling Group to apply the policy | `string` | n/a | yes |
 | cpu\_statistics | Statistics to use: [Maximum, SampleCount, Sum, Minimum, Average]. Note that resolution used in alarm generated is 1 minute. | `string` | `"Average"` | no |
-| cpu\_threshold | Keep the ECS Cluster CPU Reservation around this value. Value is in percentage (0..100). Must be specified if cpu based autoscaling is enabled. | `number` | n/a | yes |
+| cpu\_threshold | Keep the ECS Cluster CPU Reservation around this value. Value is in percentage (0..100). Must be specified if cpu based autoscaling is enabled. | `number` | `null` | no |
 | disable\_scale\_in | Indicates whether scale in by the target tracking policy is disabled. | `bool` | `false` | no |
 | ecs\_cluster\_name | Name (not ARN) of ECS Cluster that the autoscaling group is attached to | `string` | n/a | yes |
 | enable\_cpu\_based\_autoscaling | Enable Autoscaling based on ECS Cluster CPU Reservation | `bool` | `false` | no |
 | enable\_memory\_based\_autoscaling | Enable Autoscaling based on ECS Cluster Memory Reservation | `bool` | `false` | no |
 | memory\_statistics | Statistics to use: [Maximum, SampleCount, Sum, Minimum, Average]. Note that resolution used in alarm generated is 1 minute. | `string` | `"Average"` | no |
-| memory\_threshold | Keep the ECS Cluster Memory Reservation around this value. Value is in percentage (0..100). Must be specified if memory based autoscaling is enabled. | `number` | n/a | yes |
+| memory\_threshold | Keep the ECS Cluster Memory Reservation around this value. Value is in percentage (0..100). Must be specified if memory based autoscaling is enabled. | `number` | `null` | no |
 | name | Name prefix of the Autoscaling Policy | `string` | n/a | yes |
 
 ## Outputs

--- a/modules/autoscaling/ecs-target-tracking/service-utilization/README.md
+++ b/modules/autoscaling/ecs-target-tracking/service-utilization/README.md
@@ -51,19 +51,25 @@ module "ecs_service_scaling" {
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| disable\_scale\_in | Disable scale-in action, defaults to false | bool | `"false"` | no |
-| enable\_cpu\_based\_autoscaling | Enable Autoscaling based on ECS Service CPU Usage | bool | `"false"` | no |
-| enable\_memory\_based\_autoscaling | Enable Autoscaling based on ECS Service Memory Usage | bool | `"false"` | no |
-| name | Name of the ECS Policy created, will appear in Auto Scaling under Service in ECS | string | n/a | yes |
-| scalable\_target\_resource\_id | Scalable target resource id, either from resource `aws\_appautoscaling\_target` or from `core/ecs-autoscaling-target` module | string | n/a | yes |
-| scale\_in\_cooldown | Time between scale in action | number | `"300"` | no |
-| scale\_out\_cooldown | Time between scale out action | number | `"300"` | no |
-| target\_cpu\_value | Autoscale when CPU Usage value over the specified value. Must be specified if `enable\_cpu\_based\_autoscaling` is `true`. | number | `"null"` | no |
-| target\_memory\_value | Autoscale when Memory Usage value over the specified value. Must be specified if `enable\_memory\_based\_autoscaling` is `true`. | number | `"null"` | no |
+|------|-------------|------|---------|:-----:|
+| disable\_scale\_in | Disable scale-in action, defaults to false | `bool` | `false` | no |
+| enable\_cpu\_based\_autoscaling | Enable Autoscaling based on ECS Service CPU Usage | `bool` | `false` | no |
+| enable\_memory\_based\_autoscaling | Enable Autoscaling based on ECS Service Memory Usage | `bool` | `false` | no |
+| name | Name of the ECS Policy created, will appear in Auto Scaling under Service in ECS | `string` | n/a | yes |
+| scalable\_target\_resource\_id | Scalable target resource id, either from resource `aws_appautoscaling_target` or from `core/ecs-autoscaling-target` module | `string` | n/a | yes |
+| scale\_in\_cooldown | Time between scale in action | `number` | `300` | no |
+| scale\_out\_cooldown | Time between scale out action | `number` | `300` | no |
+| target\_cpu\_value | Autoscale when CPU Usage value over the specified value. Must be specified if `enable_cpu_based_autoscaling` is `true`. | `number` | n/a | yes |
+| target\_memory\_value | Autoscale when Memory Usage value over the specified value. Must be specified if `enable_memory_based_autoscaling` is `true`. | `number` | n/a | yes |
 
 ## Outputs
 

--- a/modules/autoscaling/ecs-target-tracking/service-utilization/README.md
+++ b/modules/autoscaling/ecs-target-tracking/service-utilization/README.md
@@ -51,6 +51,10 @@ module "ecs_service_scaling" {
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
 ## Providers
 
 | Name | Version |
@@ -60,7 +64,7 @@ module "ecs_service_scaling" {
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | disable\_scale\_in | Disable scale-in action, defaults to false | `bool` | `false` | no |
 | enable\_cpu\_based\_autoscaling | Enable Autoscaling based on ECS Service CPU Usage | `bool` | `false` | no |
 | enable\_memory\_based\_autoscaling | Enable Autoscaling based on ECS Service Memory Usage | `bool` | `false` | no |
@@ -68,8 +72,8 @@ module "ecs_service_scaling" {
 | scalable\_target\_resource\_id | Scalable target resource id, either from resource `aws_appautoscaling_target` or from `core/ecs-autoscaling-target` module | `string` | n/a | yes |
 | scale\_in\_cooldown | Time between scale in action | `number` | `300` | no |
 | scale\_out\_cooldown | Time between scale out action | `number` | `300` | no |
-| target\_cpu\_value | Autoscale when CPU Usage value over the specified value. Must be specified if `enable_cpu_based_autoscaling` is `true`. | `number` | n/a | yes |
-| target\_memory\_value | Autoscale when Memory Usage value over the specified value. Must be specified if `enable_memory_based_autoscaling` is `true`. | `number` | n/a | yes |
+| target\_cpu\_value | Autoscale when CPU Usage value over the specified value. Must be specified if `enable_cpu_based_autoscaling` is `true`. | `number` | `null` | no |
+| target\_memory\_value | Autoscale when Memory Usage value over the specified value. Must be specified if `enable_memory_based_autoscaling` is `true`. | `number` | `null` | no |
 
 ## Outputs
 

--- a/modules/core/ecs-autoscaling-target/README.md
+++ b/modules/core/ecs-autoscaling-target/README.md
@@ -50,6 +50,10 @@ module "ecs_service_scaling_target" {
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
 ## Providers
 
 | Name | Version |
@@ -59,7 +63,7 @@ module "ecs_service_scaling_target" {
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | ecs\_cluster\_name | ECS Cluster name to apply on (NOT ARN) | `string` | n/a | yes |
 | ecs\_service\_name | ECS Service name to apply on (NOT ARN) | `string` | n/a | yes |
 | max\_capacity | Maximum capacity of ECS autoscaling target, cannot be less than min\_capacity | `number` | n/a | yes |

--- a/modules/core/ecs-autoscaling-target/README.md
+++ b/modules/core/ecs-autoscaling-target/README.md
@@ -50,14 +50,20 @@ module "ecs_service_scaling_target" {
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| ecs\_cluster\_name | ECS Cluster name to apply on \(NOT ARN\) | string | n/a | yes |
-| ecs\_service\_name | ECS Service name to apply on \(NOT ARN\) | string | n/a | yes |
-| max\_capacity | Maximum capacity of ECS autoscaling target, cannot be less than min\_capacity | number | n/a | yes |
-| min\_capacity | Minimum capacity of ECS autoscaling target, cannot be more than max\_capacity | number | n/a | yes |
+|------|-------------|------|---------|:-----:|
+| ecs\_cluster\_name | ECS Cluster name to apply on (NOT ARN) | `string` | n/a | yes |
+| ecs\_service\_name | ECS Service name to apply on (NOT ARN) | `string` | n/a | yes |
+| max\_capacity | Maximum capacity of ECS autoscaling target, cannot be less than min\_capacity | `number` | n/a | yes |
+| min\_capacity | Minimum capacity of ECS autoscaling target, cannot be more than max\_capacity | `number` | n/a | yes |
 
 ## Outputs
 

--- a/modules/core/service/README.md
+++ b/modules/core/service/README.md
@@ -11,55 +11,61 @@ The goal of this module is to present a unified view between `ECS Service` and `
 Since this module is the closest to the `resources` form, there are a lot of customization, for those who want it easy, do check the `simple` module instead of this `core` module.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| capacity\_provider\_strategy | List of map of the capacity provider strategy to use for the service. \[Terraform Docs\]\(https://www.terraform.io/docs/providers/aws/r/ecs\_service.html#capacity\_provider\_strategy\) | list(any) | `[]` | no |
-| cluster | The cluster name or ARN. | string | n/a | yes |
-| container\_definitions | Container definitions raw json string or rendered template. Not required if `create\_task\_definition` is `false`. | string | `"null"` | no |
-| create\_task\_definition | Create the task definition | bool | `"true"` | no |
-| deployment\_controller | Type of deployment controller. Valid values: `CODE\_DEPLOY`, `ECS`. | string | `"ECS"` | no |
-| deployment\_maximum\_percent | upper limit \(% of `desired\_count`\) of # of running tasks during a deployment. Do not fill when using `DAEMON` scheduling strategy. | number | `"null"` | no |
-| deployment\_minimum\_healthy\_percent | lower limit \(% of `desired\_count`\) of # of running tasks during a deployment | number | `"100"` | no |
-| desired\_count | The number of instances of the task definition to place and keep running. Defaults to 0. Do not specify if using the `DAEMON` scheduling strategy. | number | `"null"` | no |
-| enable\_ecs\_managed\_tags | Specifies whether to enable Amazon ECS managed tags for the tasks within the service. Boolean value. | string | `"null"` | no |
-| health\_check\_grace\_period\_seconds | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 2147483647. Only valid for services configured to use load balancers. | number | `"null"` | no |
-| iam\_daemon\_role | IAM Role for ECS Agent and Docker Daemon to use \(ECR, etc.\). Required if specifying `repositoryCredentials` in container configuration. | string | `"null"` | no |
-| iam\_lb\_role | IAM Role ARN to use to attach service to Load Balancer. This parameter is required if you are using a load balancer with your service, but only if your task definition does not use the awsvpc network mode. If using awsvpc network mode, do not specify this role. If your account has already created the Amazon ECS service-linked role, that role is used by default for your service unless you specify a role here. | string | `"null"` | no |
-| iam\_task\_role | IAM Role for task to use to access AWS services \(dynamo, s3, etc.\) | string | `"null"` | no |
-| ignore\_desired\_count\_changes | Ignores any changes to `desired\_count` parameter after apply. Note updating this value will destroy the existing service and recreate it. | bool | `"false"` | no |
-| launch\_type | The launch type on which to run your service. The valid values are `EC2` or `FARGATE`. | string | `"null"` | no |
-| load\_balancers | List of map for load balancers configuration. | list(any) | `[]` | no |
-| name | The service name. | string | n/a | yes |
-| network\_configuration | Map of a network configuration for the service. This parameter is required for task definitions that use the awsvpc network mode to receive their own Elastic Network Interface, and it is not supported for other network modes. \[Terraform Docs\]\(https://www.terraform.io/docs/providers/aws/r/ecs\_service.html#network\_configuration\) | string | `"null"` | no |
-| ordered\_placement\_strategy | List of map of service level strategy rules that are taken into consideration during task placement. List from top to bottom in order of precedence. Max 5. \[Terraform Docs\]\(https://www.terraform.io/docs/providers/aws/r/ecs\_service.html#ordered\_placement\_strategy\) | list(any) | `[]` | no |
-| placement\_constraints | List of map of placement constraints for Task Definition. Max 10. \[Terraform Docs\]\(https://www.terraform.io/docs/providers/aws/r/ecs\_service.html#placement\_constraints\) | list(any) | `[]` | no |
-| platform\_version | The platform version on which to run your service. Only applicable for `launch\_type` set to `FARGATE`. Defaults to `LATEST`. \[AWS Docs\]\(https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform\_versions.html\) | string | `"null"` | no |
-| propagate\_tags | Specifies whether to propagate the tags from the task definition or the service to the tasks. The valid values are `SERVICE` and `TASK\_DEFINITION`. | string | `"null"` | no |
-| scheduling\_strategy | The scheduling strategy to use for the service. The valid values are `REPLICA` and `DAEMON`. Fargate Tasks do not support `DAEMON` scheduling strategy. | string | `"null"` | no |
-| service\_registry | Map of a service discovery registries for the service. Consists of `registry\_arn`, `port`\(optional\), `container\_port`\(optional\), `container\_port`\(optional\). \[Terraform Docs\]\(https://www.terraform.io/docs/providers/aws/r/ecs\_service.html#service\_registries\) | string | `"null"` | no |
-| tags | Key-value mapping of resource tags | map(string) | `{}` | no |
-| task\_cpu | Task level CPU units. | number | `"null"` | no |
-| task\_definition\_arn | If `create\_task\_definition` is `false`, provide the ARN of task definition to use | string | `"null"` | no |
-| task\_ipc\_mode | The IPC resource namespace to be used for the containers in the task The valid values are `host`, `task`, and `none`. | string | `"null"` | no |
-| task\_memory | Task level Memory units. | number | `"null"` | no |
-| task\_network\_mode | The network mode for container. | string | `"bridge"` | no |
-| task\_pid\_mode | The process namespace to use for the containers in the task. The valid values are `host` and `task`. | string | `"null"` | no |
-| task\_proxy\_configuration | The proxy configuration details for the App Mesh proxy. Defined as map argument. \[Terraform Docs\]\(https://www.terraform.io/docs/providers/aws/r/ecs\_task\_definition.html#proxy-configuration-arguments\) | string | `"null"` | no |
-| task\_requires\_compatibilites | A set of launch types required by the task. The valid values are `EC2` and `FARGATE`. | list(string) | `[ "EC2" ]` | no |
-| task\_volume\_configurations | Volume Block Arguments for Task Definition. List of map. Note that `docker\_volume\_configuration` should be specified as map argument instead of block. \[Terraform Docs\]\(https://www.terraform.io/docs/providers/aws/r/ecs\_task\_definition.html#volume-block-arguments\) | list(any) | `[]` | no |
+|------|-------------|------|---------|:-----:|
+| capacity\_provider\_strategy | List of map of the capacity provider strategy to use for the service. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_service.html#capacity_provider_strategy) | `list(any)` | `[]` | no |
+| cluster | The cluster name or ARN. | `string` | n/a | yes |
+| container\_definitions | Container definitions raw json string or rendered template. Not required if `create_task_definition` is `false`. | `string` | n/a | yes |
+| create\_task\_definition | Create the task definition | `bool` | `true` | no |
+| deployment\_controller | Type of deployment controller. Valid values: `CODE_DEPLOY`, `ECS`. | `string` | `"ECS"` | no |
+| deployment\_maximum\_percent | upper limit (% of `desired_count`) of # of running tasks during a deployment. Do not fill when using `DAEMON` scheduling strategy. | `number` | n/a | yes |
+| deployment\_minimum\_healthy\_percent | lower limit (% of `desired_count`) of # of running tasks during a deployment | `number` | `100` | no |
+| desired\_count | The number of instances of the task definition to place and keep running. Defaults to 0. Do not specify if using the `DAEMON` scheduling strategy. | `number` | n/a | yes |
+| enable\_ecs\_managed\_tags | Specifies whether to enable Amazon ECS managed tags for the tasks within the service. Boolean value. | `any` | n/a | yes |
+| health\_check\_grace\_period\_seconds | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 2147483647. Only valid for services configured to use load balancers. | `number` | n/a | yes |
+| iam\_daemon\_role | IAM Role for ECS Agent and Docker Daemon to use (ECR, etc.). Required if specifying `repositoryCredentials` in container configuration. | `string` | n/a | yes |
+| iam\_lb\_role | IAM Role ARN to use to attach service to Load Balancer. This parameter is required if you are using a load balancer with your service, but only if your task definition does not use the awsvpc network mode. If using awsvpc network mode, do not specify this role. If your account has already created the Amazon ECS service-linked role, that role is used by default for your service unless you specify a role here. | `string` | n/a | yes |
+| iam\_task\_role | IAM Role for task to use to access AWS services (dynamo, s3, etc.) | `string` | n/a | yes |
+| ignore\_desired\_count\_changes | Ignores any changes to `desired_count` parameter after apply. Note updating this value will destroy the existing service and recreate it. | `bool` | `false` | no |
+| launch\_type | The launch type on which to run your service. The valid values are `EC2` or `FARGATE`. | `string` | n/a | yes |
+| load\_balancers | List of map for load balancers configuration. | `list(any)` | `[]` | no |
+| name | The service name. | `string` | n/a | yes |
+| network\_configuration | Map of a network configuration for the service. This parameter is required for task definitions that use the awsvpc network mode to receive their own Elastic Network Interface, and it is not supported for other network modes. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_service.html#network_configuration) | `any` | n/a | yes |
+| ordered\_placement\_strategy | List of map of service level strategy rules that are taken into consideration during task placement. List from top to bottom in order of precedence. Max 5. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_service.html#ordered_placement_strategy) | `list(any)` | `[]` | no |
+| placement\_constraints | List of map of placement constraints for Task Definition. Max 10. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_service.html#placement_constraints) | `list(any)` | `[]` | no |
+| platform\_version | The platform version on which to run your service. Only applicable for `launch_type` set to `FARGATE`. Defaults to `LATEST`. [AWS Docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html) | `string` | n/a | yes |
+| propagate\_tags | Specifies whether to propagate the tags from the task definition or the service to the tasks. The valid values are `SERVICE` and `TASK_DEFINITION`. | `string` | n/a | yes |
+| scheduling\_strategy | The scheduling strategy to use for the service. The valid values are `REPLICA` and `DAEMON`. Fargate Tasks do not support `DAEMON` scheduling strategy. | `string` | n/a | yes |
+| service\_registry | Map of a service discovery registries for the service. Consists of `registry_arn`, `port`(optional), `container_port`(optional), `container_port`(optional). [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_service.html#service_registries) | `any` | n/a | yes |
+| tags | Key-value mapping of resource tags | `map(string)` | `{}` | no |
+| task\_cpu | Task level CPU units. | `number` | n/a | yes |
+| task\_definition\_arn | If `create_task_definition` is `false`, provide the ARN of task definition to use | `string` | n/a | yes |
+| task\_ipc\_mode | The IPC resource namespace to be used for the containers in the task The valid values are `host`, `task`, and `none`. | `string` | n/a | yes |
+| task\_memory | Task level Memory units. | `number` | n/a | yes |
+| task\_network\_mode | The network mode for container. | `string` | `"bridge"` | no |
+| task\_pid\_mode | The process namespace to use for the containers in the task. The valid values are `host` and `task`. | `string` | n/a | yes |
+| task\_proxy\_configuration | The proxy configuration details for the App Mesh proxy. Defined as map argument. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#proxy-configuration-arguments) | `any` | n/a | yes |
+| task\_requires\_compatibilites | A set of launch types required by the task. The valid values are `EC2` and `FARGATE`. | `list(string)` | <pre>[<br>  "EC2"<br>]</pre> | no |
+| task\_volume\_configurations | Volume Block Arguments for Task Definition. List of map. Note that `docker_volume_configuration` should be specified as map argument instead of block. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#volume-block-arguments) | `list(any)` | `[]` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| cluster | The Amazon Resource Name \(ARN\) of cluster which the service runs on |
+| cluster | The Amazon Resource Name (ARN) of cluster which the service runs on |
 | desired\_count | The number of instances of the task definition |
-| id | The Amazon Resource Name \(ARN\) that identifies the service |
+| id | The Amazon Resource Name (ARN) that identifies the service |
 | name | The name of the service |
 | task\_definition\_arn | The complete ARN of task definition generated includes Task Family and Task Revision |
-| task\_definition\_name | The name \(family\) of created Task Definition. |
+| task\_definition\_name | The name (family) of created Task Definition. |
 | task\_definition\_revision | The revision of the task in a particular family |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/core/service/README.md
+++ b/modules/core/service/README.md
@@ -11,6 +11,10 @@ The goal of this module is to present a unified view between `ECS Service` and `
 Since this module is the closest to the `resources` form, there are a lot of customization, for those who want it easy, do check the `simple` module instead of this `core` module.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
 ## Providers
 
 | Name | Version |
@@ -20,39 +24,39 @@ Since this module is the closest to the `resources` form, there are a lot of cus
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | capacity\_provider\_strategy | List of map of the capacity provider strategy to use for the service. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_service.html#capacity_provider_strategy) | `list(any)` | `[]` | no |
 | cluster | The cluster name or ARN. | `string` | n/a | yes |
-| container\_definitions | Container definitions raw json string or rendered template. Not required if `create_task_definition` is `false`. | `string` | n/a | yes |
+| container\_definitions | Container definitions raw json string or rendered template. Not required if `create_task_definition` is `false`. | `string` | `null` | no |
 | create\_task\_definition | Create the task definition | `bool` | `true` | no |
 | deployment\_controller | Type of deployment controller. Valid values: `CODE_DEPLOY`, `ECS`. | `string` | `"ECS"` | no |
-| deployment\_maximum\_percent | upper limit (% of `desired_count`) of # of running tasks during a deployment. Do not fill when using `DAEMON` scheduling strategy. | `number` | n/a | yes |
+| deployment\_maximum\_percent | upper limit (% of `desired_count`) of # of running tasks during a deployment. Do not fill when using `DAEMON` scheduling strategy. | `number` | `null` | no |
 | deployment\_minimum\_healthy\_percent | lower limit (% of `desired_count`) of # of running tasks during a deployment | `number` | `100` | no |
-| desired\_count | The number of instances of the task definition to place and keep running. Defaults to 0. Do not specify if using the `DAEMON` scheduling strategy. | `number` | n/a | yes |
-| enable\_ecs\_managed\_tags | Specifies whether to enable Amazon ECS managed tags for the tasks within the service. Boolean value. | `any` | n/a | yes |
-| health\_check\_grace\_period\_seconds | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 2147483647. Only valid for services configured to use load balancers. | `number` | n/a | yes |
-| iam\_daemon\_role | IAM Role for ECS Agent and Docker Daemon to use (ECR, etc.). Required if specifying `repositoryCredentials` in container configuration. | `string` | n/a | yes |
-| iam\_lb\_role | IAM Role ARN to use to attach service to Load Balancer. This parameter is required if you are using a load balancer with your service, but only if your task definition does not use the awsvpc network mode. If using awsvpc network mode, do not specify this role. If your account has already created the Amazon ECS service-linked role, that role is used by default for your service unless you specify a role here. | `string` | n/a | yes |
-| iam\_task\_role | IAM Role for task to use to access AWS services (dynamo, s3, etc.) | `string` | n/a | yes |
+| desired\_count | The number of instances of the task definition to place and keep running. Defaults to 0. Do not specify if using the `DAEMON` scheduling strategy. | `number` | `null` | no |
+| enable\_ecs\_managed\_tags | Specifies whether to enable Amazon ECS managed tags for the tasks within the service. Boolean value. | `any` | `null` | no |
+| health\_check\_grace\_period\_seconds | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 2147483647. Only valid for services configured to use load balancers. | `number` | `null` | no |
+| iam\_daemon\_role | IAM Role for ECS Agent and Docker Daemon to use (ECR, etc.). Required if specifying `repositoryCredentials` in container configuration. | `string` | `null` | no |
+| iam\_lb\_role | IAM Role ARN to use to attach service to Load Balancer. This parameter is required if you are using a load balancer with your service, but only if your task definition does not use the awsvpc network mode. If using awsvpc network mode, do not specify this role. If your account has already created the Amazon ECS service-linked role, that role is used by default for your service unless you specify a role here. | `string` | `null` | no |
+| iam\_task\_role | IAM Role for task to use to access AWS services (dynamo, s3, etc.) | `string` | `null` | no |
 | ignore\_desired\_count\_changes | Ignores any changes to `desired_count` parameter after apply. Note updating this value will destroy the existing service and recreate it. | `bool` | `false` | no |
-| launch\_type | The launch type on which to run your service. The valid values are `EC2` or `FARGATE`. | `string` | n/a | yes |
+| launch\_type | The launch type on which to run your service. The valid values are `EC2` or `FARGATE`. | `string` | `null` | no |
 | load\_balancers | List of map for load balancers configuration. | `list(any)` | `[]` | no |
 | name | The service name. | `string` | n/a | yes |
-| network\_configuration | Map of a network configuration for the service. This parameter is required for task definitions that use the awsvpc network mode to receive their own Elastic Network Interface, and it is not supported for other network modes. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_service.html#network_configuration) | `any` | n/a | yes |
+| network\_configuration | Map of a network configuration for the service. This parameter is required for task definitions that use the awsvpc network mode to receive their own Elastic Network Interface, and it is not supported for other network modes. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_service.html#network_configuration) | `any` | `null` | no |
 | ordered\_placement\_strategy | List of map of service level strategy rules that are taken into consideration during task placement. List from top to bottom in order of precedence. Max 5. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_service.html#ordered_placement_strategy) | `list(any)` | `[]` | no |
 | placement\_constraints | List of map of placement constraints for Task Definition. Max 10. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_service.html#placement_constraints) | `list(any)` | `[]` | no |
-| platform\_version | The platform version on which to run your service. Only applicable for `launch_type` set to `FARGATE`. Defaults to `LATEST`. [AWS Docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html) | `string` | n/a | yes |
-| propagate\_tags | Specifies whether to propagate the tags from the task definition or the service to the tasks. The valid values are `SERVICE` and `TASK_DEFINITION`. | `string` | n/a | yes |
-| scheduling\_strategy | The scheduling strategy to use for the service. The valid values are `REPLICA` and `DAEMON`. Fargate Tasks do not support `DAEMON` scheduling strategy. | `string` | n/a | yes |
-| service\_registry | Map of a service discovery registries for the service. Consists of `registry_arn`, `port`(optional), `container_port`(optional), `container_port`(optional). [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_service.html#service_registries) | `any` | n/a | yes |
+| platform\_version | The platform version on which to run your service. Only applicable for `launch_type` set to `FARGATE`. Defaults to `LATEST`. [AWS Docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html) | `string` | `null` | no |
+| propagate\_tags | Specifies whether to propagate the tags from the task definition or the service to the tasks. The valid values are `SERVICE` and `TASK_DEFINITION`. | `string` | `null` | no |
+| scheduling\_strategy | The scheduling strategy to use for the service. The valid values are `REPLICA` and `DAEMON`. Fargate Tasks do not support `DAEMON` scheduling strategy. | `string` | `null` | no |
+| service\_registry | Map of a service discovery registries for the service. Consists of `registry_arn`, `port`(optional), `container_port`(optional), `container_port`(optional). [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_service.html#service_registries) | `any` | `null` | no |
 | tags | Key-value mapping of resource tags | `map(string)` | `{}` | no |
-| task\_cpu | Task level CPU units. | `number` | n/a | yes |
-| task\_definition\_arn | If `create_task_definition` is `false`, provide the ARN of task definition to use | `string` | n/a | yes |
-| task\_ipc\_mode | The IPC resource namespace to be used for the containers in the task The valid values are `host`, `task`, and `none`. | `string` | n/a | yes |
-| task\_memory | Task level Memory units. | `number` | n/a | yes |
+| task\_cpu | Task level CPU units. | `number` | `null` | no |
+| task\_definition\_arn | If `create_task_definition` is `false`, provide the ARN of task definition to use | `string` | `null` | no |
+| task\_ipc\_mode | The IPC resource namespace to be used for the containers in the task The valid values are `host`, `task`, and `none`. | `string` | `null` | no |
+| task\_memory | Task level Memory units. | `number` | `null` | no |
 | task\_network\_mode | The network mode for container. | `string` | `"bridge"` | no |
-| task\_pid\_mode | The process namespace to use for the containers in the task. The valid values are `host` and `task`. | `string` | n/a | yes |
-| task\_proxy\_configuration | The proxy configuration details for the App Mesh proxy. Defined as map argument. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#proxy-configuration-arguments) | `any` | n/a | yes |
+| task\_pid\_mode | The process namespace to use for the containers in the task. The valid values are `host` and `task`. | `string` | `null` | no |
+| task\_proxy\_configuration | The proxy configuration details for the App Mesh proxy. Defined as map argument. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#proxy-configuration-arguments) | `any` | `null` | no |
 | task\_requires\_compatibilites | A set of launch types required by the task. The valid values are `EC2` and `FARGATE`. | `list(string)` | <pre>[<br>  "EC2"<br>]</pre> | no |
 | task\_volume\_configurations | Volume Block Arguments for Task Definition. List of map. Note that `docker_volume_configuration` should be specified as map argument instead of block. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#volume-block-arguments) | `list(any)` | `[]` | no |
 

--- a/modules/core/task/README.md
+++ b/modules/core/task/README.md
@@ -7,6 +7,10 @@ There should be no need to instantiate this module directly except if you know w
 Almost a 1-1 mapping to `resources`.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
 ## Providers
 
 | Name | Version |
@@ -16,21 +20,21 @@ Almost a 1-1 mapping to `resources`.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | container\_definitions | Container definitions raw json string or rendered template. | `string` | n/a | yes |
-| cpu | CPU unit for this task. | `number` | n/a | yes |
+| cpu | CPU unit for this task. | `number` | `null` | no |
 | create\_task\_definition | Create the Task Definition | `bool` | `true` | no |
-| daemon\_role | The IAM Role to assign for the ECS container agent and Docker daemon. | `string` | n/a | yes |
-| ipc\_mode | The IPC resource namespace to be used for the containers in the task The valid values are `host`, `task`, and `none`. | `string` | n/a | yes |
-| memory | Memory for this task. | `number` | n/a | yes |
+| daemon\_role | The IAM Role to assign for the ECS container agent and Docker daemon. | `string` | `null` | no |
+| ipc\_mode | The IPC resource namespace to be used for the containers in the task The valid values are `host`, `task`, and `none`. | `string` | `null` | no |
+| memory | Memory for this task. | `number` | `null` | no |
 | name | The task name. | `string` | n/a | yes |
 | network\_mode | The network mode for container. | `string` | `"bridge"` | no |
-| pid\_mode | The process namespace to use for the containers in the task. The valid values are `host` and `task`. | `string` | n/a | yes |
+| pid\_mode | The process namespace to use for the containers in the task. The valid values are `host` and `task`. | `string` | `null` | no |
 | placement\_constraints | Placement constraints for Task Definition. List of map. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#placement_constraints) | `list(any)` | `[]` | no |
-| proxy\_configuration | The proxy configuration details for the App Mesh proxy. Defined as map argument. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#proxy-configuration-arguments) | `any` | n/a | yes |
+| proxy\_configuration | The proxy configuration details for the App Mesh proxy. Defined as map argument. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#proxy-configuration-arguments) | `any` | `null` | no |
 | requires\_compatibilites | A set of launch types required by the task. The valid values are EC2 and FARGATE. | `list(string)` | <pre>[<br>  "EC2"<br>]</pre> | no |
 | tags | Key-value mapping of resource tags. | `map(string)` | `{}` | no |
-| task\_role | The IAM Role to assign to the Container. | `string` | n/a | yes |
+| task\_role | The IAM Role to assign to the Container. | `string` | `null` | no |
 | volume\_configurations | Volume Block Arguments for Task Definition. List of map. Note that `docker_volume_configuration` should be specified as map argument instead of block. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#volume-block-arguments) | `list(any)` | `[]` | no |
 
 ## Outputs

--- a/modules/core/task/README.md
+++ b/modules/core/task/README.md
@@ -7,31 +7,37 @@ There should be no need to instantiate this module directly except if you know w
 Almost a 1-1 mapping to `resources`.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| container\_definitions | Container definitions raw json string or rendered template. | string | n/a | yes |
-| cpu | CPU unit for this task. | number | `"null"` | no |
-| create\_task\_definition | Create the Task Definition | bool | `"true"` | no |
-| daemon\_role | The IAM Role to assign for the ECS container agent and Docker daemon. | string | `"null"` | no |
-| ipc\_mode | The IPC resource namespace to be used for the containers in the task The valid values are `host`, `task`, and `none`. | string | `"null"` | no |
-| memory | Memory for this task. | number | `"null"` | no |
-| name | The task name. | string | n/a | yes |
-| network\_mode | The network mode for container. | string | `"bridge"` | no |
-| pid\_mode | The process namespace to use for the containers in the task. The valid values are `host` and `task`. | string | `"null"` | no |
-| placement\_constraints | Placement constraints for Task Definition. List of map. \[Terraform Docs\]\(https://www.terraform.io/docs/providers/aws/r/ecs\_task\_definition.html#placement\_constraints\) | list(any) | `[]` | no |
-| proxy\_configuration | The proxy configuration details for the App Mesh proxy. Defined as map argument. \[Terraform Docs\]\(https://www.terraform.io/docs/providers/aws/r/ecs\_task\_definition.html#proxy-configuration-arguments\) | string | `"null"` | no |
-| requires\_compatibilites | A set of launch types required by the task. The valid values are EC2 and FARGATE. | list(string) | `[ "EC2" ]` | no |
-| tags | Key-value mapping of resource tags. | map(string) | `{}` | no |
-| task\_role | The IAM Role to assign to the Container. | string | `"null"` | no |
-| volume\_configurations | Volume Block Arguments for Task Definition. List of map. Note that `docker\_volume\_configuration` should be specified as map argument instead of block. \[Terraform Docs\]\(https://www.terraform.io/docs/providers/aws/r/ecs\_task\_definition.html#volume-block-arguments\) | list(any) | `[]` | no |
+|------|-------------|------|---------|:-----:|
+| container\_definitions | Container definitions raw json string or rendered template. | `string` | n/a | yes |
+| cpu | CPU unit for this task. | `number` | n/a | yes |
+| create\_task\_definition | Create the Task Definition | `bool` | `true` | no |
+| daemon\_role | The IAM Role to assign for the ECS container agent and Docker daemon. | `string` | n/a | yes |
+| ipc\_mode | The IPC resource namespace to be used for the containers in the task The valid values are `host`, `task`, and `none`. | `string` | n/a | yes |
+| memory | Memory for this task. | `number` | n/a | yes |
+| name | The task name. | `string` | n/a | yes |
+| network\_mode | The network mode for container. | `string` | `"bridge"` | no |
+| pid\_mode | The process namespace to use for the containers in the task. The valid values are `host` and `task`. | `string` | n/a | yes |
+| placement\_constraints | Placement constraints for Task Definition. List of map. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#placement_constraints) | `list(any)` | `[]` | no |
+| proxy\_configuration | The proxy configuration details for the App Mesh proxy. Defined as map argument. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#proxy-configuration-arguments) | `any` | n/a | yes |
+| requires\_compatibilites | A set of launch types required by the task. The valid values are EC2 and FARGATE. | `list(string)` | <pre>[<br>  "EC2"<br>]</pre> | no |
+| tags | Key-value mapping of resource tags. | `map(string)` | `{}` | no |
+| task\_role | The IAM Role to assign to the Container. | `string` | n/a | yes |
+| volume\_configurations | Volume Block Arguments for Task Definition. List of map. Note that `docker_volume_configuration` should be specified as map argument instead of block. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#volume-block-arguments) | `list(any)` | `[]` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| arn | Full ARN of the Task Definition \(including both `family` and `revision`\). |
+| arn | Full ARN of the Task Definition (including both `family` and `revision`). |
 | name | The created task definition name |
 | revision | The revision number of the task definition |
 

--- a/modules/iam/ecs-instance-profile/README.md
+++ b/modules/iam/ecs-instance-profile/README.md
@@ -5,11 +5,17 @@ Module to generate IAM Instance Profile (and Role) for EC2 instances backing ECS
 * [More ECS policy examples explained](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/IAMPolicyExamples.html)
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| name | Name prefix to be used on generated resources | string | n/a | yes |
+|------|-------------|------|---------|:-----:|
+| name | Name prefix to be used on generated resources | `string` | n/a | yes |
 
 ## Outputs
 

--- a/modules/iam/ecs-instance-profile/README.md
+++ b/modules/iam/ecs-instance-profile/README.md
@@ -5,6 +5,10 @@ Module to generate IAM Instance Profile (and Role) for EC2 instances backing ECS
 * [More ECS policy examples explained](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/IAMPolicyExamples.html)
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
 ## Providers
 
 | Name | Version |
@@ -14,7 +18,7 @@ Module to generate IAM Instance Profile (and Role) for EC2 instances backing ECS
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | name | Name prefix to be used on generated resources | `string` | n/a | yes |
 
 ## Outputs

--- a/modules/scheduled-actions/README.md
+++ b/modules/scheduled-actions/README.md
@@ -71,6 +71,10 @@ module "ecs_fargate_cron" {
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
 ## Providers
 
 | Name | Version |
@@ -80,9 +84,9 @@ module "ecs_fargate_cron" {
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | cluster\_arn | ECS Cluster ARN to run ECS Task in | `string` | n/a | yes |
-| container\_overrides | Overrides options of container. Expecting JSON. See https://www.terraform.io/docs/providers/aws/r/cloudwatch_event_target.html#example-ecs-run-task-with-role-and-task-override-usage | `string` | n/a | yes |
+| container\_overrides | Overrides options of container. Expecting JSON. See https://www.terraform.io/docs/providers/aws/r/cloudwatch_event_target.html#example-ecs-run-task-with-role-and-task-override-usage | `string` | `null` | no |
 | fargate\_assign\_public\_ip | Assign Public IP or not to Fargate task, specify if `is_fargate` | `bool` | `false` | no |
 | fargate\_security\_groups | Security groups to assign to Fargate task, specify if `is_fargate` | `list(string)` | `[]` | no |
 | fargate\_subnets | Subnets to assign to Fargate task, specify if `is_fargate` | `list(string)` | `[]` | no |

--- a/modules/scheduled-actions/README.md
+++ b/modules/scheduled-actions/README.md
@@ -71,28 +71,34 @@ module "ecs_fargate_cron" {
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| cluster\_arn | ECS Cluster ARN to run ECS Task in | string | n/a | yes |
-| container\_overrides | Overrides options of container. Expecting JSON. See https://www.terraform.io/docs/providers/aws/r/cloudwatch\_event\_target.html#example-ecs-run-task-with-role-and-task-override-usage | string | `"null"` | no |
-| fargate\_assign\_public\_ip | Assign Public IP or not to Fargate task, specify if `is\_fargate` | bool | `"false"` | no |
-| fargate\_security\_groups | Security groups to assign to Fargate task, specify if `is\_fargate` | list(string) | `[]` | no |
-| fargate\_subnets | Subnets to assign to Fargate task, specify if `is\_fargate` | list(string) | `[]` | no |
-| iam\_invoker | IAM ARN to invoke ECS Task | string | n/a | yes |
-| is\_fargate | Task is fargate | bool | `"false"` | no |
-| name | Name for scheduled action | string | n/a | yes |
-| schedule\_description | The description of the rule | string | `"Cloudwatch event rule to invoke ECS Task"` | no |
-| schedule\_rule | Schedule in cron or rate \(see: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html for rules\) | string | n/a | yes |
-| task\_count | Desired ECS Task count to run | number | n/a | yes |
-| task\_definition\_arn | Task definition ARN to run | string | n/a | yes |
+|------|-------------|------|---------|:-----:|
+| cluster\_arn | ECS Cluster ARN to run ECS Task in | `string` | n/a | yes |
+| container\_overrides | Overrides options of container. Expecting JSON. See https://www.terraform.io/docs/providers/aws/r/cloudwatch_event_target.html#example-ecs-run-task-with-role-and-task-override-usage | `string` | n/a | yes |
+| fargate\_assign\_public\_ip | Assign Public IP or not to Fargate task, specify if `is_fargate` | `bool` | `false` | no |
+| fargate\_security\_groups | Security groups to assign to Fargate task, specify if `is_fargate` | `list(string)` | `[]` | no |
+| fargate\_subnets | Subnets to assign to Fargate task, specify if `is_fargate` | `list(string)` | `[]` | no |
+| iam\_invoker | IAM ARN to invoke ECS Task | `string` | n/a | yes |
+| is\_fargate | Task is fargate | `bool` | `false` | no |
+| name | Name for scheduled action | `string` | n/a | yes |
+| schedule\_description | The description of the rule | `string` | `"Cloudwatch event rule to invoke ECS Task"` | no |
+| schedule\_rule | Schedule in cron or rate (see: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html for rules) | `string` | n/a | yes |
+| task\_count | Desired ECS Task count to run | `number` | n/a | yes |
+| task\_definition\_arn | Task definition ARN to run | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| arn | The Amazon Resource Name \(ARN\) of the rule. |
+| arn | The Amazon Resource Name (ARN) of the rule. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/modules/simple/ec2/README.md
+++ b/modules/simple/ec2/README.md
@@ -15,6 +15,10 @@ Creates the following:
 - ECS Task Definition
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
 ## Providers
 
 No provider.
@@ -22,29 +26,29 @@ No provider.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
-| capacity\_provider\_arn | Run the service only on this capacity provider | `string` | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| capacity\_provider\_arn | Run the service only on this capacity provider | `string` | `null` | no |
 | cluster | The cluster name or ARN. | `string` | n/a | yes |
 | container\_definitions | Container definitions raw json string or rendered template. Not required if `create_task_definition` is `false`. | `string` | n/a | yes |
-| container\_name | Container name to register to Load Balancer | `string` | n/a | yes |
-| container\_port | The container port, must match the container exposed port | `string` | n/a | yes |
-| cpu | CPU unit for this task | `number` | n/a | yes |
-| deployment\_maximum\_percent | upper limit (% of `desired_count`) of # of running tasks during a deployment. Do not fill when using `DAEMON` scheduling strategy. | `number` | n/a | yes |
+| container\_name | Container name to register to Load Balancer | `string` | `null` | no |
+| container\_port | The container port, must match the container exposed port | `string` | `null` | no |
+| cpu | CPU unit for this task | `number` | `null` | no |
+| deployment\_maximum\_percent | upper limit (% of `desired_count`) of # of running tasks during a deployment. Do not fill when using `DAEMON` scheduling strategy. | `number` | `null` | no |
 | deployment\_minimum\_healthy\_percent | lower limit (% of `desired_count`) of # of running tasks during a deployment | `number` | `100` | no |
-| desired\_count | The number of instances of the task definition to place and keep running. Defaults to 0. Do not specify if using the `DAEMON` scheduling strategy. | `number` | n/a | yes |
-| elb\_name | Name of ELB (Classic ELB) to associate with the service | `string` | n/a | yes |
-| health\_check\_grace\_period\_seconds | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 2147483647. Only valid for services configured to use load balancers. | `number` | n/a | yes |
-| iam\_daemon\_role | IAM Role for ECS Agent and Docker Daemon to use (ECR, etc.). Required if specifying `repositoryCredentials` in container configuration. | `string` | n/a | yes |
-| iam\_lb\_role | IAM Role ARN to use to attach service to Load Balancer. This parameter is required if you are using a load balancer with your service, but only if your task definition does not use the awsvpc network mode. If using awsvpc network mode, do not specify this role. If your account has already created the Amazon ECS service-linked role, that role is used by default for your service unless you specify a role here. | `string` | n/a | yes |
-| iam\_task\_role | IAM Role for task to use to access AWS services (dynamo, s3, etc.) | `string` | n/a | yes |
+| desired\_count | The number of instances of the task definition to place and keep running. Defaults to 0. Do not specify if using the `DAEMON` scheduling strategy. | `number` | `null` | no |
+| elb\_name | Name of ELB (Classic ELB) to associate with the service | `string` | `null` | no |
+| health\_check\_grace\_period\_seconds | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 2147483647. Only valid for services configured to use load balancers. | `number` | `null` | no |
+| iam\_daemon\_role | IAM Role for ECS Agent and Docker Daemon to use (ECR, etc.). Required if specifying `repositoryCredentials` in container configuration. | `string` | `null` | no |
+| iam\_lb\_role | IAM Role ARN to use to attach service to Load Balancer. This parameter is required if you are using a load balancer with your service, but only if your task definition does not use the awsvpc network mode. If using awsvpc network mode, do not specify this role. If your account has already created the Amazon ECS service-linked role, that role is used by default for your service unless you specify a role here. | `string` | `null` | no |
+| iam\_task\_role | IAM Role for task to use to access AWS services (dynamo, s3, etc.) | `string` | `null` | no |
 | ignore\_desired\_count\_changes | Ignores any changes to `desired_count` parameter after apply. Note updating this value will destroy the existing service and recreate it. | `bool` | `false` | no |
-| memory | Memory for this task | `number` | n/a | yes |
+| memory | Memory for this task | `number` | `null` | no |
 | name | The service name. | `string` | n/a | yes |
 | network\_mode | Network mode of the container, valid options are none, bridge, awsvpc, and host | `string` | `"bridge"` | no |
-| proxy\_configuration | The proxy configuration details for the App Mesh proxy. Defined as map argument. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#proxy-configuration-arguments) | `any` | n/a | yes |
-| service\_registry | Map of a service discovery registries for the service. Consists of `registry_arn`, `port`(optional), `container_port`(optional), `container_port`(optional). [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_service.html#service_registries) | `any` | n/a | yes |
+| proxy\_configuration | The proxy configuration details for the App Mesh proxy. Defined as map argument. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#proxy-configuration-arguments) | `any` | `null` | no |
+| service\_registry | Map of a service discovery registries for the service. Consists of `registry_arn`, `port`(optional), `container_port`(optional), `container_port`(optional). [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_service.html#service_registries) | `any` | `null` | no |
 | tags | Key-value mapping of resource tags | `map(string)` | `{}` | no |
-| target\_group\_arn | ARN of the Application Load Balancer / Network Load Balancer target group | `string` | n/a | yes |
+| target\_group\_arn | ARN of the Application Load Balancer / Network Load Balancer target group | `string` | `null` | no |
 | volume\_configurations | Volume Block Arguments for Task Definition. List of map. Note that `docker_volume_configuration` should be specified as map argument instead of block. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#volume-block-arguments) | `list(any)` | `[]` | no |
 
 ## Outputs

--- a/modules/simple/ec2/README.md
+++ b/modules/simple/ec2/README.md
@@ -15,44 +15,48 @@ Creates the following:
 - ECS Task Definition
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+No provider.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| capacity\_provider\_arn | Run the service only on this capacity provider | string | `"null"` | no |
-| cluster | The cluster name or ARN. | string | n/a | yes |
-| container\_definitions | Container definitions raw json string or rendered template. Not required if `create\_task\_definition` is `false`. | string | n/a | yes |
-| container\_name | Container name to register to Load Balancer | string | `"null"` | no |
-| container\_port | The container port, must match the container exposed port | string | `"null"` | no |
-| cpu | CPU unit for this task | number | `"null"` | no |
-| deployment\_maximum\_percent | upper limit \(% of `desired\_count`\) of # of running tasks during a deployment. Do not fill when using `DAEMON` scheduling strategy. | number | `"null"` | no |
-| deployment\_minimum\_healthy\_percent | lower limit \(% of `desired\_count`\) of # of running tasks during a deployment | number | `"100"` | no |
-| desired\_count | The number of instances of the task definition to place and keep running. Defaults to 0. Do not specify if using the `DAEMON` scheduling strategy. | number | `"null"` | no |
-| elb\_name | Name of ELB \(Classic ELB\) to associate with the service | string | `"null"` | no |
-| health\_check\_grace\_period\_seconds | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 2147483647. Only valid for services configured to use load balancers. | number | `"null"` | no |
-| iam\_daemon\_role | IAM Role for ECS Agent and Docker Daemon to use \(ECR, etc.\). Required if specifying `repositoryCredentials` in container configuration. | string | `"null"` | no |
-| iam\_lb\_role | IAM Role ARN to use to attach service to Load Balancer. This parameter is required if you are using a load balancer with your service, but only if your task definition does not use the awsvpc network mode. If using awsvpc network mode, do not specify this role. If your account has already created the Amazon ECS service-linked role, that role is used by default for your service unless you specify a role here. | string | `"null"` | no |
-| iam\_task\_role | IAM Role for task to use to access AWS services \(dynamo, s3, etc.\) | string | `"null"` | no |
-| ignore\_desired\_count\_changes | Ignores any changes to `desired\_count` parameter after apply. Note updating this value will destroy the existing service and recreate it. | bool | `"false"` | no |
-| memory | Memory for this task | number | `"null"` | no |
-| name | The service name. | string | n/a | yes |
-| network\_mode | Network mode of the container, valid options are none, bridge, awsvpc, and host | string | `"bridge"` | no |
-| proxy\_configuration | The proxy configuration details for the App Mesh proxy. Defined as map argument. \[Terraform Docs\]\(https://www.terraform.io/docs/providers/aws/r/ecs\_task\_definition.html#proxy-configuration-arguments\) | string | `"null"` | no |
-| service\_registry | Map of a service discovery registries for the service. Consists of `registry\_arn`, `port`\(optional\), `container\_port`\(optional\), `container\_port`\(optional\). \[Terraform Docs\]\(https://www.terraform.io/docs/providers/aws/r/ecs\_service.html#service\_registries\) | string | `"null"` | no |
-| tags | Key-value mapping of resource tags | map(string) | `{}` | no |
-| target\_group\_arn | ARN of the Application Load Balancer / Network Load Balancer target group | string | `"null"` | no |
-| volume\_configurations | Volume Block Arguments for Task Definition. List of map. Note that `docker\_volume\_configuration` should be specified as map argument instead of block. \[Terraform Docs\]\(https://www.terraform.io/docs/providers/aws/r/ecs\_task\_definition.html#volume-block-arguments\) | list(any) | `[]` | no |
+|------|-------------|------|---------|:-----:|
+| capacity\_provider\_arn | Run the service only on this capacity provider | `string` | n/a | yes |
+| cluster | The cluster name or ARN. | `string` | n/a | yes |
+| container\_definitions | Container definitions raw json string or rendered template. Not required if `create_task_definition` is `false`. | `string` | n/a | yes |
+| container\_name | Container name to register to Load Balancer | `string` | n/a | yes |
+| container\_port | The container port, must match the container exposed port | `string` | n/a | yes |
+| cpu | CPU unit for this task | `number` | n/a | yes |
+| deployment\_maximum\_percent | upper limit (% of `desired_count`) of # of running tasks during a deployment. Do not fill when using `DAEMON` scheduling strategy. | `number` | n/a | yes |
+| deployment\_minimum\_healthy\_percent | lower limit (% of `desired_count`) of # of running tasks during a deployment | `number` | `100` | no |
+| desired\_count | The number of instances of the task definition to place and keep running. Defaults to 0. Do not specify if using the `DAEMON` scheduling strategy. | `number` | n/a | yes |
+| elb\_name | Name of ELB (Classic ELB) to associate with the service | `string` | n/a | yes |
+| health\_check\_grace\_period\_seconds | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 2147483647. Only valid for services configured to use load balancers. | `number` | n/a | yes |
+| iam\_daemon\_role | IAM Role for ECS Agent and Docker Daemon to use (ECR, etc.). Required if specifying `repositoryCredentials` in container configuration. | `string` | n/a | yes |
+| iam\_lb\_role | IAM Role ARN to use to attach service to Load Balancer. This parameter is required if you are using a load balancer with your service, but only if your task definition does not use the awsvpc network mode. If using awsvpc network mode, do not specify this role. If your account has already created the Amazon ECS service-linked role, that role is used by default for your service unless you specify a role here. | `string` | n/a | yes |
+| iam\_task\_role | IAM Role for task to use to access AWS services (dynamo, s3, etc.) | `string` | n/a | yes |
+| ignore\_desired\_count\_changes | Ignores any changes to `desired_count` parameter after apply. Note updating this value will destroy the existing service and recreate it. | `bool` | `false` | no |
+| memory | Memory for this task | `number` | n/a | yes |
+| name | The service name. | `string` | n/a | yes |
+| network\_mode | Network mode of the container, valid options are none, bridge, awsvpc, and host | `string` | `"bridge"` | no |
+| proxy\_configuration | The proxy configuration details for the App Mesh proxy. Defined as map argument. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#proxy-configuration-arguments) | `any` | n/a | yes |
+| service\_registry | Map of a service discovery registries for the service. Consists of `registry_arn`, `port`(optional), `container_port`(optional), `container_port`(optional). [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_service.html#service_registries) | `any` | n/a | yes |
+| tags | Key-value mapping of resource tags | `map(string)` | `{}` | no |
+| target\_group\_arn | ARN of the Application Load Balancer / Network Load Balancer target group | `string` | n/a | yes |
+| volume\_configurations | Volume Block Arguments for Task Definition. List of map. Note that `docker_volume_configuration` should be specified as map argument instead of block. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#volume-block-arguments) | `list(any)` | `[]` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| cluster | The Amazon Resource Name \(ARN\) of cluster which the service runs on |
+| cluster | The Amazon Resource Name (ARN) of cluster which the service runs on |
 | desired\_count | The number of instances of the task definition |
-| id | The Amazon Resource Name \(ARN\) that identifies the service |
+| id | The Amazon Resource Name (ARN) that identifies the service |
 | name | The name of the service |
 | task\_definition\_arn | The complete ARN of task definition generated includes Task Family and Task Revision |
-| task\_definition\_name | The name \(family\) of created Task Definition. |
+| task\_definition\_name | The name (family) of created Task Definition. |
 | task\_definition\_revision | The revision of the task in a particular family |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/simple/fargate-spot/README.md
+++ b/modules/simple/fargate-spot/README.md
@@ -19,47 +19,51 @@ Creates the following:
 - ECS Task Definition
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+No provider.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| assign\_public\_ip | Assign public IP to the ENI | bool | `"false"` | no |
-| cluster | The cluster name or ARN. | string | n/a | yes |
-| container\_definitions | Container definitions raw json string or rendered template. Not required if `create\_task\_definition` is `false`. | string | n/a | yes |
-| container\_name | Container name to register to Load Balancer | string | `"null"` | no |
-| container\_port | The container port, must match the container exposed port | string | `"null"` | no |
-| cpu | CPU unit for this task | number | n/a | yes |
-| deployment\_maximum\_percent | upper limit \(% of `desired\_count`\) of # of running tasks during a deployment. Do not fill when using `DAEMON` scheduling strategy. | number | `"null"` | no |
-| deployment\_minimum\_healthy\_percent | lower limit \(% of `desired\_count`\) of # of running tasks during a deployment | number | `"100"` | no |
-| desired\_count | The number of instances of the task definition to place and keep running. Defaults to 0. Do not specify if using the `DAEMON` scheduling strategy. | number | `"null"` | no |
-| elb\_name | Name of ELB \(Classic ELB\) to associate with the service | string | `"null"` | no |
-| health\_check\_grace\_period\_seconds | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 2147483647. Only valid for services configured to use load balancers. | number | `"null"` | no |
-| iam\_daemon\_role | IAM Role for ECS Agent and Docker Daemon to use \(ECR, etc.\). Required if specifying `repositoryCredentials` in container configuration. | string | `"null"` | no |
-| iam\_lb\_role | IAM Role ARN to use to attach service to Load Balancer. This parameter is required if you are using a load balancer with your service, but only if your task definition does not use the awsvpc network mode. If using awsvpc network mode, do not specify this role. If your account has already created the Amazon ECS service-linked role, that role is used by default for your service unless you specify a role here. | string | `"null"` | no |
-| iam\_task\_role | IAM Role for task to use to access AWS services \(dynamo, s3, etc.\) | string | `"null"` | no |
-| ignore\_desired\_count\_changes | Ignores any changes to `desired\_count` parameter after apply. Note updating this value will destroy the existing service and recreate it. | bool | `"false"` | no |
-| memory | Memory for this task | number | n/a | yes |
-| name | The service name. | string | n/a | yes |
-| num\_of\_task\_on\_demand | The number of task to run on FARGATE on-demand that must run all the time. Note: Changing this number after creation will destroy and recreate the service \(downtime\). | number | `"0"` | no |
-| platform\_version | The platform version on which to run your service. Defaults to `LATEST`. \[AWS Docs\]\(https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform\_versions.html\) | string | `"null"` | no |
-| proxy\_configuration | The proxy configuration details for the App Mesh proxy. Defined as map argument. \[Terraform Docs\]\(https://www.terraform.io/docs/providers/aws/r/ecs\_task\_definition.html#proxy-configuration-arguments\) | string | `"null"` | no |
-| security\_groups | Security Groups to apply for the task | list(string) | n/a | yes |
-| service\_registry | Map of a service discovery registries for the service. Consists of `registry\_arn`, `port`\(optional\), `container\_port`\(optional\), `container\_port`\(optional\). \[Terraform Docs\]\(https://www.terraform.io/docs/providers/aws/r/ecs\_service.html#service\_registries\) | string | `"null"` | no |
-| tags | Key-value mapping of resource tags | map(string) | `{}` | no |
-| target\_group\_arn | ARN of the Application Load Balancer / Network Load Balancer target group | string | `"null"` | no |
-| volume\_configurations | Volume Block Arguments for Task Definition. List of map. Note that `docker\_volume\_configuration` should be specified as map argument instead of block. \[Terraform Docs\]\(https://www.terraform.io/docs/providers/aws/r/ecs\_task\_definition.html#volume-block-arguments\) | list(any) | `[]` | no |
-| vpc\_subnets | VPC Subnets where the tasks should live in | list(string) | n/a | yes |
+|------|-------------|------|---------|:-----:|
+| assign\_public\_ip | Assign public IP to the ENI | `bool` | `false` | no |
+| cluster | The cluster name or ARN. | `string` | n/a | yes |
+| container\_definitions | Container definitions raw json string or rendered template. Not required if `create_task_definition` is `false`. | `string` | n/a | yes |
+| container\_name | Container name to register to Load Balancer | `string` | n/a | yes |
+| container\_port | The container port, must match the container exposed port | `string` | n/a | yes |
+| cpu | CPU unit for this task | `number` | n/a | yes |
+| deployment\_maximum\_percent | upper limit (% of `desired_count`) of # of running tasks during a deployment. Do not fill when using `DAEMON` scheduling strategy. | `number` | n/a | yes |
+| deployment\_minimum\_healthy\_percent | lower limit (% of `desired_count`) of # of running tasks during a deployment | `number` | `100` | no |
+| desired\_count | The number of instances of the task definition to place and keep running. Defaults to 0. Do not specify if using the `DAEMON` scheduling strategy. | `number` | n/a | yes |
+| elb\_name | Name of ELB (Classic ELB) to associate with the service | `string` | n/a | yes |
+| health\_check\_grace\_period\_seconds | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 2147483647. Only valid for services configured to use load balancers. | `number` | n/a | yes |
+| iam\_daemon\_role | IAM Role for ECS Agent and Docker Daemon to use (ECR, etc.). Required if specifying `repositoryCredentials` in container configuration. | `string` | n/a | yes |
+| iam\_lb\_role | IAM Role ARN to use to attach service to Load Balancer. This parameter is required if you are using a load balancer with your service, but only if your task definition does not use the awsvpc network mode. If using awsvpc network mode, do not specify this role. If your account has already created the Amazon ECS service-linked role, that role is used by default for your service unless you specify a role here. | `string` | n/a | yes |
+| iam\_task\_role | IAM Role for task to use to access AWS services (dynamo, s3, etc.) | `string` | n/a | yes |
+| ignore\_desired\_count\_changes | Ignores any changes to `desired_count` parameter after apply. Note updating this value will destroy the existing service and recreate it. | `bool` | `false` | no |
+| memory | Memory for this task | `number` | n/a | yes |
+| name | The service name. | `string` | n/a | yes |
+| num\_of\_task\_on\_demand | The number of task to run on FARGATE on-demand that must run all the time. Note: Changing this number after creation will destroy and recreate the service (downtime). | `number` | `0` | no |
+| platform\_version | The platform version on which to run your service. Defaults to `LATEST`. [AWS Docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html) | `string` | n/a | yes |
+| proxy\_configuration | The proxy configuration details for the App Mesh proxy. Defined as map argument. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#proxy-configuration-arguments) | `any` | n/a | yes |
+| security\_groups | Security Groups to apply for the task | `list(string)` | n/a | yes |
+| service\_registry | Map of a service discovery registries for the service. Consists of `registry_arn`, `port`(optional), `container_port`(optional), `container_port`(optional). [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_service.html#service_registries) | `any` | n/a | yes |
+| tags | Key-value mapping of resource tags | `map(string)` | `{}` | no |
+| target\_group\_arn | ARN of the Application Load Balancer / Network Load Balancer target group | `string` | n/a | yes |
+| volume\_configurations | Volume Block Arguments for Task Definition. List of map. Note that `docker_volume_configuration` should be specified as map argument instead of block. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#volume-block-arguments) | `list(any)` | `[]` | no |
+| vpc\_subnets | VPC Subnets where the tasks should live in | `list(string)` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| cluster | The Amazon Resource Name \(ARN\) of cluster which the service runs on |
+| cluster | The Amazon Resource Name (ARN) of cluster which the service runs on |
 | desired\_count | The number of instances of the task definition |
-| id | The Amazon Resource Name \(ARN\) that identifies the service |
+| id | The Amazon Resource Name (ARN) that identifies the service |
 | name | The name of the service |
 | task\_definition\_arn | The complete ARN of task definition generated includes Task Family and Task Revision |
-| task\_definition\_name | The name \(family\) of created Task Definition. |
+| task\_definition\_name | The name (family) of created Task Definition. |
 | task\_definition\_revision | The revision of the task in a particular family |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/simple/fargate-spot/README.md
+++ b/modules/simple/fargate-spot/README.md
@@ -19,6 +19,10 @@ Creates the following:
 - ECS Task Definition
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
 ## Providers
 
 No provider.
@@ -26,31 +30,31 @@ No provider.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | assign\_public\_ip | Assign public IP to the ENI | `bool` | `false` | no |
 | cluster | The cluster name or ARN. | `string` | n/a | yes |
 | container\_definitions | Container definitions raw json string or rendered template. Not required if `create_task_definition` is `false`. | `string` | n/a | yes |
-| container\_name | Container name to register to Load Balancer | `string` | n/a | yes |
-| container\_port | The container port, must match the container exposed port | `string` | n/a | yes |
+| container\_name | Container name to register to Load Balancer | `string` | `null` | no |
+| container\_port | The container port, must match the container exposed port | `string` | `null` | no |
 | cpu | CPU unit for this task | `number` | n/a | yes |
-| deployment\_maximum\_percent | upper limit (% of `desired_count`) of # of running tasks during a deployment. Do not fill when using `DAEMON` scheduling strategy. | `number` | n/a | yes |
+| deployment\_maximum\_percent | upper limit (% of `desired_count`) of # of running tasks during a deployment. Do not fill when using `DAEMON` scheduling strategy. | `number` | `null` | no |
 | deployment\_minimum\_healthy\_percent | lower limit (% of `desired_count`) of # of running tasks during a deployment | `number` | `100` | no |
-| desired\_count | The number of instances of the task definition to place and keep running. Defaults to 0. Do not specify if using the `DAEMON` scheduling strategy. | `number` | n/a | yes |
-| elb\_name | Name of ELB (Classic ELB) to associate with the service | `string` | n/a | yes |
-| health\_check\_grace\_period\_seconds | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 2147483647. Only valid for services configured to use load balancers. | `number` | n/a | yes |
-| iam\_daemon\_role | IAM Role for ECS Agent and Docker Daemon to use (ECR, etc.). Required if specifying `repositoryCredentials` in container configuration. | `string` | n/a | yes |
-| iam\_lb\_role | IAM Role ARN to use to attach service to Load Balancer. This parameter is required if you are using a load balancer with your service, but only if your task definition does not use the awsvpc network mode. If using awsvpc network mode, do not specify this role. If your account has already created the Amazon ECS service-linked role, that role is used by default for your service unless you specify a role here. | `string` | n/a | yes |
-| iam\_task\_role | IAM Role for task to use to access AWS services (dynamo, s3, etc.) | `string` | n/a | yes |
+| desired\_count | The number of instances of the task definition to place and keep running. Defaults to 0. Do not specify if using the `DAEMON` scheduling strategy. | `number` | `null` | no |
+| elb\_name | Name of ELB (Classic ELB) to associate with the service | `string` | `null` | no |
+| health\_check\_grace\_period\_seconds | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 2147483647. Only valid for services configured to use load balancers. | `number` | `null` | no |
+| iam\_daemon\_role | IAM Role for ECS Agent and Docker Daemon to use (ECR, etc.). Required if specifying `repositoryCredentials` in container configuration. | `string` | `null` | no |
+| iam\_lb\_role | IAM Role ARN to use to attach service to Load Balancer. This parameter is required if you are using a load balancer with your service, but only if your task definition does not use the awsvpc network mode. If using awsvpc network mode, do not specify this role. If your account has already created the Amazon ECS service-linked role, that role is used by default for your service unless you specify a role here. | `string` | `null` | no |
+| iam\_task\_role | IAM Role for task to use to access AWS services (dynamo, s3, etc.) | `string` | `null` | no |
 | ignore\_desired\_count\_changes | Ignores any changes to `desired_count` parameter after apply. Note updating this value will destroy the existing service and recreate it. | `bool` | `false` | no |
 | memory | Memory for this task | `number` | n/a | yes |
 | name | The service name. | `string` | n/a | yes |
 | num\_of\_task\_on\_demand | The number of task to run on FARGATE on-demand that must run all the time. Note: Changing this number after creation will destroy and recreate the service (downtime). | `number` | `0` | no |
-| platform\_version | The platform version on which to run your service. Defaults to `LATEST`. [AWS Docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html) | `string` | n/a | yes |
-| proxy\_configuration | The proxy configuration details for the App Mesh proxy. Defined as map argument. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#proxy-configuration-arguments) | `any` | n/a | yes |
+| platform\_version | The platform version on which to run your service. Defaults to `LATEST`. [AWS Docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html) | `string` | `null` | no |
+| proxy\_configuration | The proxy configuration details for the App Mesh proxy. Defined as map argument. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#proxy-configuration-arguments) | `any` | `null` | no |
 | security\_groups | Security Groups to apply for the task | `list(string)` | n/a | yes |
-| service\_registry | Map of a service discovery registries for the service. Consists of `registry_arn`, `port`(optional), `container_port`(optional), `container_port`(optional). [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_service.html#service_registries) | `any` | n/a | yes |
+| service\_registry | Map of a service discovery registries for the service. Consists of `registry_arn`, `port`(optional), `container_port`(optional), `container_port`(optional). [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_service.html#service_registries) | `any` | `null` | no |
 | tags | Key-value mapping of resource tags | `map(string)` | `{}` | no |
-| target\_group\_arn | ARN of the Application Load Balancer / Network Load Balancer target group | `string` | n/a | yes |
+| target\_group\_arn | ARN of the Application Load Balancer / Network Load Balancer target group | `string` | `null` | no |
 | volume\_configurations | Volume Block Arguments for Task Definition. List of map. Note that `docker_volume_configuration` should be specified as map argument instead of block. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#volume-block-arguments) | `list(any)` | `[]` | no |
 | vpc\_subnets | VPC Subnets where the tasks should live in | `list(string)` | n/a | yes |
 

--- a/modules/simple/fargate/README.md
+++ b/modules/simple/fargate/README.md
@@ -15,6 +15,10 @@ Creates the following:
 - ECS Task Definition
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
 ## Providers
 
 No provider.
@@ -22,30 +26,30 @@ No provider.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | assign\_public\_ip | Assign public IP to the ENI | `bool` | `false` | no |
 | cluster | The cluster name or ARN. | `string` | n/a | yes |
 | container\_definitions | Container definitions raw json string or rendered template. Not required if `create_task_definition` is `false`. | `string` | n/a | yes |
-| container\_name | Container name to register to Load Balancer | `string` | n/a | yes |
-| container\_port | The container port, must match the container exposed port | `string` | n/a | yes |
+| container\_name | Container name to register to Load Balancer | `string` | `null` | no |
+| container\_port | The container port, must match the container exposed port | `string` | `null` | no |
 | cpu | CPU unit for this task | `number` | n/a | yes |
-| deployment\_maximum\_percent | upper limit (% of `desired_count`) of # of running tasks during a deployment. Do not fill when using `DAEMON` scheduling strategy. | `number` | n/a | yes |
+| deployment\_maximum\_percent | upper limit (% of `desired_count`) of # of running tasks during a deployment. Do not fill when using `DAEMON` scheduling strategy. | `number` | `null` | no |
 | deployment\_minimum\_healthy\_percent | lower limit (% of `desired_count`) of # of running tasks during a deployment | `number` | `100` | no |
-| desired\_count | The number of instances of the task definition to place and keep running. Defaults to 0. Do not specify if using the `DAEMON` scheduling strategy. | `number` | n/a | yes |
-| elb\_name | Name of ELB (Classic ELB) to associate with the service | `string` | n/a | yes |
-| health\_check\_grace\_period\_seconds | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 2147483647. Only valid for services configured to use load balancers. | `number` | n/a | yes |
-| iam\_daemon\_role | IAM Role for ECS Agent and Docker Daemon to use (ECR, etc.). Required if specifying `repositoryCredentials` in container configuration. | `string` | n/a | yes |
-| iam\_lb\_role | IAM Role ARN to use to attach service to Load Balancer. This parameter is required if you are using a load balancer with your service, but only if your task definition does not use the awsvpc network mode. If using awsvpc network mode, do not specify this role. If your account has already created the Amazon ECS service-linked role, that role is used by default for your service unless you specify a role here. | `string` | n/a | yes |
-| iam\_task\_role | IAM Role for task to use to access AWS services (dynamo, s3, etc.) | `string` | n/a | yes |
+| desired\_count | The number of instances of the task definition to place and keep running. Defaults to 0. Do not specify if using the `DAEMON` scheduling strategy. | `number` | `null` | no |
+| elb\_name | Name of ELB (Classic ELB) to associate with the service | `string` | `null` | no |
+| health\_check\_grace\_period\_seconds | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 2147483647. Only valid for services configured to use load balancers. | `number` | `null` | no |
+| iam\_daemon\_role | IAM Role for ECS Agent and Docker Daemon to use (ECR, etc.). Required if specifying `repositoryCredentials` in container configuration. | `string` | `null` | no |
+| iam\_lb\_role | IAM Role ARN to use to attach service to Load Balancer. This parameter is required if you are using a load balancer with your service, but only if your task definition does not use the awsvpc network mode. If using awsvpc network mode, do not specify this role. If your account has already created the Amazon ECS service-linked role, that role is used by default for your service unless you specify a role here. | `string` | `null` | no |
+| iam\_task\_role | IAM Role for task to use to access AWS services (dynamo, s3, etc.) | `string` | `null` | no |
 | ignore\_desired\_count\_changes | Ignores any changes to `desired_count` parameter after apply. Note updating this value will destroy the existing service and recreate it. | `bool` | `false` | no |
 | memory | Memory for this task | `number` | n/a | yes |
 | name | The service name. | `string` | n/a | yes |
-| platform\_version | The platform version on which to run your service. Defaults to `LATEST`. [AWS Docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html) | `string` | n/a | yes |
-| proxy\_configuration | The proxy configuration details for the App Mesh proxy. Defined as map argument. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#proxy-configuration-arguments) | `any` | n/a | yes |
+| platform\_version | The platform version on which to run your service. Defaults to `LATEST`. [AWS Docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html) | `string` | `null` | no |
+| proxy\_configuration | The proxy configuration details for the App Mesh proxy. Defined as map argument. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#proxy-configuration-arguments) | `any` | `null` | no |
 | security\_groups | Security Groups to apply for the task | `list(string)` | n/a | yes |
-| service\_registry | Map of a service discovery registries for the service. Consists of `registry_arn`, `port`(optional), `container_port`(optional), `container_port`(optional). [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_service.html#service_registries) | `any` | n/a | yes |
+| service\_registry | Map of a service discovery registries for the service. Consists of `registry_arn`, `port`(optional), `container_port`(optional), `container_port`(optional). [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_service.html#service_registries) | `any` | `null` | no |
 | tags | Key-value mapping of resource tags | `map(string)` | `{}` | no |
-| target\_group\_arn | ARN of the Application Load Balancer / Network Load Balancer target group | `string` | n/a | yes |
+| target\_group\_arn | ARN of the Application Load Balancer / Network Load Balancer target group | `string` | `null` | no |
 | volume\_configurations | Volume Block Arguments for Task Definition. List of map. Note that `docker_volume_configuration` should be specified as map argument instead of block. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#volume-block-arguments) | `list(any)` | `[]` | no |
 | vpc\_subnets | VPC Subnets where the tasks should live in | `list(string)` | n/a | yes |
 

--- a/modules/simple/fargate/README.md
+++ b/modules/simple/fargate/README.md
@@ -15,46 +15,50 @@ Creates the following:
 - ECS Task Definition
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+No provider.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| assign\_public\_ip | Assign public IP to the ENI | bool | `"false"` | no |
-| cluster | The cluster name or ARN. | string | n/a | yes |
-| container\_definitions | Container definitions raw json string or rendered template. Not required if `create\_task\_definition` is `false`. | string | n/a | yes |
-| container\_name | Container name to register to Load Balancer | string | `"null"` | no |
-| container\_port | The container port, must match the container exposed port | string | `"null"` | no |
-| cpu | CPU unit for this task | number | n/a | yes |
-| deployment\_maximum\_percent | upper limit \(% of `desired\_count`\) of # of running tasks during a deployment. Do not fill when using `DAEMON` scheduling strategy. | number | `"null"` | no |
-| deployment\_minimum\_healthy\_percent | lower limit \(% of `desired\_count`\) of # of running tasks during a deployment | number | `"100"` | no |
-| desired\_count | The number of instances of the task definition to place and keep running. Defaults to 0. Do not specify if using the `DAEMON` scheduling strategy. | number | `"null"` | no |
-| elb\_name | Name of ELB \(Classic ELB\) to associate with the service | string | `"null"` | no |
-| health\_check\_grace\_period\_seconds | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 2147483647. Only valid for services configured to use load balancers. | number | `"null"` | no |
-| iam\_daemon\_role | IAM Role for ECS Agent and Docker Daemon to use \(ECR, etc.\). Required if specifying `repositoryCredentials` in container configuration. | string | `"null"` | no |
-| iam\_lb\_role | IAM Role ARN to use to attach service to Load Balancer. This parameter is required if you are using a load balancer with your service, but only if your task definition does not use the awsvpc network mode. If using awsvpc network mode, do not specify this role. If your account has already created the Amazon ECS service-linked role, that role is used by default for your service unless you specify a role here. | string | `"null"` | no |
-| iam\_task\_role | IAM Role for task to use to access AWS services \(dynamo, s3, etc.\) | string | `"null"` | no |
-| ignore\_desired\_count\_changes | Ignores any changes to `desired\_count` parameter after apply. Note updating this value will destroy the existing service and recreate it. | bool | `"false"` | no |
-| memory | Memory for this task | number | n/a | yes |
-| name | The service name. | string | n/a | yes |
-| platform\_version | The platform version on which to run your service. Defaults to `LATEST`. \[AWS Docs\]\(https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform\_versions.html\) | string | `"null"` | no |
-| proxy\_configuration | The proxy configuration details for the App Mesh proxy. Defined as map argument. \[Terraform Docs\]\(https://www.terraform.io/docs/providers/aws/r/ecs\_task\_definition.html#proxy-configuration-arguments\) | string | `"null"` | no |
-| security\_groups | Security Groups to apply for the task | list(string) | n/a | yes |
-| service\_registry | Map of a service discovery registries for the service. Consists of `registry\_arn`, `port`\(optional\), `container\_port`\(optional\), `container\_port`\(optional\). \[Terraform Docs\]\(https://www.terraform.io/docs/providers/aws/r/ecs\_service.html#service\_registries\) | string | `"null"` | no |
-| tags | Key-value mapping of resource tags | map(string) | `{}` | no |
-| target\_group\_arn | ARN of the Application Load Balancer / Network Load Balancer target group | string | `"null"` | no |
-| volume\_configurations | Volume Block Arguments for Task Definition. List of map. Note that `docker\_volume\_configuration` should be specified as map argument instead of block. \[Terraform Docs\]\(https://www.terraform.io/docs/providers/aws/r/ecs\_task\_definition.html#volume-block-arguments\) | list(any) | `[]` | no |
-| vpc\_subnets | VPC Subnets where the tasks should live in | list(string) | n/a | yes |
+|------|-------------|------|---------|:-----:|
+| assign\_public\_ip | Assign public IP to the ENI | `bool` | `false` | no |
+| cluster | The cluster name or ARN. | `string` | n/a | yes |
+| container\_definitions | Container definitions raw json string or rendered template. Not required if `create_task_definition` is `false`. | `string` | n/a | yes |
+| container\_name | Container name to register to Load Balancer | `string` | n/a | yes |
+| container\_port | The container port, must match the container exposed port | `string` | n/a | yes |
+| cpu | CPU unit for this task | `number` | n/a | yes |
+| deployment\_maximum\_percent | upper limit (% of `desired_count`) of # of running tasks during a deployment. Do not fill when using `DAEMON` scheduling strategy. | `number` | n/a | yes |
+| deployment\_minimum\_healthy\_percent | lower limit (% of `desired_count`) of # of running tasks during a deployment | `number` | `100` | no |
+| desired\_count | The number of instances of the task definition to place and keep running. Defaults to 0. Do not specify if using the `DAEMON` scheduling strategy. | `number` | n/a | yes |
+| elb\_name | Name of ELB (Classic ELB) to associate with the service | `string` | n/a | yes |
+| health\_check\_grace\_period\_seconds | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 2147483647. Only valid for services configured to use load balancers. | `number` | n/a | yes |
+| iam\_daemon\_role | IAM Role for ECS Agent and Docker Daemon to use (ECR, etc.). Required if specifying `repositoryCredentials` in container configuration. | `string` | n/a | yes |
+| iam\_lb\_role | IAM Role ARN to use to attach service to Load Balancer. This parameter is required if you are using a load balancer with your service, but only if your task definition does not use the awsvpc network mode. If using awsvpc network mode, do not specify this role. If your account has already created the Amazon ECS service-linked role, that role is used by default for your service unless you specify a role here. | `string` | n/a | yes |
+| iam\_task\_role | IAM Role for task to use to access AWS services (dynamo, s3, etc.) | `string` | n/a | yes |
+| ignore\_desired\_count\_changes | Ignores any changes to `desired_count` parameter after apply. Note updating this value will destroy the existing service and recreate it. | `bool` | `false` | no |
+| memory | Memory for this task | `number` | n/a | yes |
+| name | The service name. | `string` | n/a | yes |
+| platform\_version | The platform version on which to run your service. Defaults to `LATEST`. [AWS Docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html) | `string` | n/a | yes |
+| proxy\_configuration | The proxy configuration details for the App Mesh proxy. Defined as map argument. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#proxy-configuration-arguments) | `any` | n/a | yes |
+| security\_groups | Security Groups to apply for the task | `list(string)` | n/a | yes |
+| service\_registry | Map of a service discovery registries for the service. Consists of `registry_arn`, `port`(optional), `container_port`(optional), `container_port`(optional). [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_service.html#service_registries) | `any` | n/a | yes |
+| tags | Key-value mapping of resource tags | `map(string)` | `{}` | no |
+| target\_group\_arn | ARN of the Application Load Balancer / Network Load Balancer target group | `string` | n/a | yes |
+| volume\_configurations | Volume Block Arguments for Task Definition. List of map. Note that `docker_volume_configuration` should be specified as map argument instead of block. [Terraform Docs](https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#volume-block-arguments) | `list(any)` | `[]` | no |
+| vpc\_subnets | VPC Subnets where the tasks should live in | `list(string)` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| cluster | The Amazon Resource Name \(ARN\) of cluster which the service runs on |
+| cluster | The Amazon Resource Name (ARN) of cluster which the service runs on |
 | desired\_count | The number of instances of the task definition |
-| id | The Amazon Resource Name \(ARN\) that identifies the service |
+| id | The Amazon Resource Name (ARN) that identifies the service |
 | name | The name of the service |
 | task\_definition\_arn | The complete ARN of task definition generated includes Task Family and Task Revision |
-| task\_definition\_name | The name \(family\) of created Task Definition. |
+| task\_definition\_name | The name (family) of created Task Definition. |
 | task\_definition\_revision | The revision of the task in a particular family |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->


### PR DESCRIPTION
Fix
>An argument named "dimensions" is not expected here. Did you mean to define a block of type "dimensions"?

Also updates pre-commit hook, as it fails the test