### PR TITLE
Update output description

### DIFF
--- a/modules/core/service/README.md
+++ b/modules/core/service/README.md
@@ -64,7 +64,7 @@ No requirements.
 
 | Name | Description |
 |------|-------------|
-| cluster | The Amazon Resource Name (ARN) of cluster which the service runs on |
+| cluster | The name of the cluster which the service runs on |
 | desired\_count | The number of instances of the task definition |
 | id | The Amazon Resource Name (ARN) that identifies the service |
 | name | The name of the service |

--- a/modules/core/service/output.tf
+++ b/modules/core/service/output.tf
@@ -21,7 +21,7 @@ output "name" {
 }
 
 output "cluster" {
-  description = "The Amazon Resource Name (ARN) of cluster which the service runs on"
+  description = "The name of the cluster which the service runs on"
   value       = local.this_service_cluster_name
 }
 


### PR DESCRIPTION
Fixes #6 
Having `Amazon Resource Name (ARN)` in the description made me think it was a properly formatted `arn` instead of just the name.
Maybe changing the description text might make it clearer?