### PR TITLE
Fix capacity provider count

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ resource "aws_ecs_cluster" "main" {
 }
 
 resource "aws_ecs_cluster_capacity_providers" "main" {
-  count = var.capacity_providers != null || var.default_capacity_provider_strategy != [] ? 1 : 0
+  count = var.capacity_providers != null || length(var.default_capacity_provider_strategy) > 0 ? 1 : 0
 
   cluster_name = aws_ecs_cluster.main.name
 

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,7 @@
+locals {
+  create_capacity_provider = var.capacity_providers != null || length(var.default_capacity_provider_strategy) > 0
+}
+
 resource "aws_ecs_cluster" "main" {
   name = var.name
 
@@ -25,7 +29,7 @@ resource "aws_ecs_cluster" "main" {
 }
 
 resource "aws_ecs_cluster_capacity_providers" "main" {
-  count = var.capacity_providers != null || length(var.default_capacity_provider_strategy) > 0 ? 1 : 0
+  count = local.create_capacity_provider ? 1 : 0
 
   cluster_name = aws_ecs_cluster.main.name
 


### PR DESCRIPTION
`var.default_capacity_provider_strategy != []` will always return True, so the count will always be 1 even if capacity provider is not set. (https://discuss.hashicorp.com/t/conditional-for-empty-list/26958/3)

