### PR TITLE
Fix examples security group issues by upgrading version

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -106,7 +106,7 @@ jobs:
           terraform_version: ${{ matrix.version }}
       - name: Install pre-commit dependency - terraform-docs
         run: |
-          TF_DOCS_VER="v0.14.1"
+          TF_DOCS_VER="v0.16.0"
           pushd /tmp
             curl -Lo ./terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/${TF_DOCS_VER}/terraform-docs-${TF_DOCS_VER}-$(uname)-amd64.tar.gz && tar -xzf terraform-docs.tar.gz && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
           popd

--- a/examples/easy/ec2-alb/README.md
+++ b/examples/easy/ec2-alb/README.md
@@ -31,19 +31,19 @@ To test that it's working:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.74.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.42.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_alb"></a> [alb](#module\_alb) | terraform-aws-modules/alb/aws | 5.13.0 |
-| <a name="module_alb_security_group"></a> [alb\_security\_group](#module\_alb\_security\_group) | terraform-aws-modules/security-group/aws | 3.2.0 |
+| <a name="module_alb_security_group"></a> [alb\_security\_group](#module\_alb\_security\_group) | terraform-aws-modules/security-group/aws | ~> 4.0 |
 | <a name="module_asg"></a> [asg](#module\_asg) | terraform-aws-modules/autoscaling/aws | ~> 3.0 |
 | <a name="module_easy_ec2"></a> [easy\_ec2](#module\_easy\_ec2) | ../../../modules/simple/ec2 | n/a |
-| <a name="module_ec2_security_group"></a> [ec2\_security\_group](#module\_ec2\_security\_group) | terraform-aws-modules/security-group/aws | 3.2.0 |
+| <a name="module_ec2_security_group"></a> [ec2\_security\_group](#module\_ec2\_security\_group) | terraform-aws-modules/security-group/aws | ~> 4.0 |
 | <a name="module_ecs_cluster"></a> [ecs\_cluster](#module\_ecs\_cluster) | ../../.. | n/a |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 2.18.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 2 |
 
 ## Resources
 

--- a/examples/easy/ec2-alb/README.md
+++ b/examples/easy/ec2-alb/README.md
@@ -31,7 +31,7 @@ To test that it's working:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.42.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.74.0 |
 
 ## Modules
 

--- a/examples/easy/ec2-alb/main.tf
+++ b/examples/easy/ec2-alb/main.tf
@@ -16,7 +16,7 @@ locals {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "2.18.0"
+  version = "~> 2"
 
   name = "${local.prefix}-vpc"
   cidr = local.vpc_cidr
@@ -36,7 +36,7 @@ module "vpc" {
 
 module "alb_security_group" {
   source  = "terraform-aws-modules/security-group/aws"
-  version = "3.2.0"
+  version = "~> 4.0"
 
   name   = "${local.prefix}-alb-sg"
   vpc_id = module.vpc.vpc_id
@@ -54,7 +54,7 @@ module "alb_security_group" {
 
 module "ec2_security_group" {
   source  = "terraform-aws-modules/security-group/aws"
-  version = "3.2.0"
+  version = "~> 4.0"
 
   name   = "${local.prefix}-ec2-sg"
   vpc_id = module.vpc.vpc_id
@@ -65,7 +65,7 @@ module "ec2_security_group" {
   computed_ingress_with_source_security_group_id = [
     {
       rule                     = "all-all"
-      source_security_group_id = module.alb_security_group.this_security_group_id
+      source_security_group_id = module.alb_security_group.security_group_id
     }
   ]
 
@@ -81,7 +81,7 @@ module "alb" {
 
   name               = "${local.prefix}-alb"
   load_balancer_type = "application"
-  security_groups    = [module.alb_security_group.this_security_group_id]
+  security_groups    = [module.alb_security_group.security_group_id]
   subnets            = module.vpc.public_subnets
   vpc_id             = module.vpc.vpc_id
 
@@ -113,7 +113,7 @@ module "asg" {
 
   image_id                    = data.aws_ssm_parameter.ami_image.value
   instance_type               = "t2.micro"
-  security_groups             = [module.ec2_security_group.this_security_group_id]
+  security_groups             = [module.ec2_security_group.security_group_id]
   vpc_zone_identifier         = module.vpc.public_subnets
   min_size                    = 1
   max_size                    = 2

--- a/examples/easy/ec2/README.md
+++ b/examples/easy/ec2/README.md
@@ -37,17 +37,17 @@ $ terraform apply
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.74.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.42.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_asg"></a> [asg](#module\_asg) | terraform-aws-modules/autoscaling/aws | ~> 3.0 |
+| <a name="module_asg"></a> [asg](#module\_asg) | terraform-aws-modules/autoscaling/aws | ~> 4.0 |
 | <a name="module_easy_ec2"></a> [easy\_ec2](#module\_easy\_ec2) | ../../../modules/simple/ec2 | n/a |
-| <a name="module_ec2_security_group"></a> [ec2\_security\_group](#module\_ec2\_security\_group) | terraform-aws-modules/security-group/aws | 3.2.0 |
+| <a name="module_ec2_security_group"></a> [ec2\_security\_group](#module\_ec2\_security\_group) | terraform-aws-modules/security-group/aws | ~> 4.0 |
 | <a name="module_ecs_cluster"></a> [ecs\_cluster](#module\_ecs\_cluster) | ../../.. | n/a |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 2.18.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 2 |
 
 ## Resources
 

--- a/examples/easy/ec2/README.md
+++ b/examples/easy/ec2/README.md
@@ -37,7 +37,7 @@ $ terraform apply
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.42.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.74.0 |
 
 ## Modules
 

--- a/examples/easy/ec2/main.tf
+++ b/examples/easy/ec2/main.tf
@@ -16,7 +16,7 @@ locals {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "2.18.0"
+  version = "~> 2"
 
   name = "${local.prefix}-vpc"
   cidr = local.vpc_cidr
@@ -36,7 +36,7 @@ module "vpc" {
 
 module "ec2_security_group" {
   source  = "terraform-aws-modules/security-group/aws"
-  version = "3.2.0"
+  version = "~> 4.0"
 
   name   = "${local.prefix}-ec2-sg"
   vpc_id = module.vpc.vpc_id
@@ -55,13 +55,13 @@ module "ec2_security_group" {
 
 module "asg" {
   source  = "terraform-aws-modules/autoscaling/aws"
-  version = "~> 3.0"
+  version = "~> 4.0"
 
   name = "${local.prefix}-asg"
 
   image_id                    = data.aws_ssm_parameter.ami_image.value
   instance_type               = "t2.micro"
-  security_groups             = [module.ec2_security_group.this_security_group_id]
+  security_groups             = [module.ec2_security_group.security_group_id]
   vpc_zone_identifier         = module.vpc.public_subnets
   min_size                    = 1
   max_size                    = 2
@@ -71,7 +71,7 @@ module "asg" {
   user_data = templatefile("../../templates/ec2_userdata.tpl", {
     ecs_cluster = module.ecs_cluster.name
   })
-  iam_instance_profile = var.instance_profile_arn
+  iam_instance_profile_arn = var.instance_profile_arn
 }
 
 # This module usage starts here

--- a/examples/easy/fargate-alb/README.md
+++ b/examples/easy/fargate-alb/README.md
@@ -38,7 +38,7 @@ $ terraform apply
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.42.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.74.0 |
 
 ## Modules
 

--- a/examples/easy/fargate-alb/README.md
+++ b/examples/easy/fargate-alb/README.md
@@ -38,18 +38,18 @@ $ terraform apply
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.74.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.42.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_alb"></a> [alb](#module\_alb) | terraform-aws-modules/alb/aws | 5.13.0 |
-| <a name="module_alb_security_group"></a> [alb\_security\_group](#module\_alb\_security\_group) | terraform-aws-modules/security-group/aws | 3.2.0 |
+| <a name="module_alb_security_group"></a> [alb\_security\_group](#module\_alb\_security\_group) | terraform-aws-modules/security-group/aws | ~> 4.0 |
 | <a name="module_easy_fargate"></a> [easy\_fargate](#module\_easy\_fargate) | ../../../modules/simple/fargate | n/a |
 | <a name="module_ecs_cluster"></a> [ecs\_cluster](#module\_ecs\_cluster) | ../../.. | n/a |
-| <a name="module_task_security_group"></a> [task\_security\_group](#module\_task\_security\_group) | terraform-aws-modules/security-group/aws | 3.2.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 2.18.0 |
+| <a name="module_task_security_group"></a> [task\_security\_group](#module\_task\_security\_group) | terraform-aws-modules/security-group/aws | ~> 4.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 2 |
 
 ## Resources
 

--- a/examples/easy/fargate-alb/main.tf
+++ b/examples/easy/fargate-alb/main.tf
@@ -12,7 +12,7 @@ locals {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "2.18.0"
+  version = "~> 2"
 
   name = "${local.prefix}-vpc"
   cidr = local.vpc_cidr
@@ -32,7 +32,7 @@ module "vpc" {
 
 module "alb_security_group" {
   source  = "terraform-aws-modules/security-group/aws"
-  version = "3.2.0"
+  version = "~> 4.0"
 
   name   = "${local.prefix}-alb-sg"
   vpc_id = module.vpc.vpc_id
@@ -50,7 +50,7 @@ module "alb_security_group" {
 
 module "task_security_group" {
   source  = "terraform-aws-modules/security-group/aws"
-  version = "3.2.0"
+  version = "~> 4.0"
 
   name   = "${local.prefix}-task-sg"
   vpc_id = module.vpc.vpc_id
@@ -61,7 +61,7 @@ module "task_security_group" {
   computed_ingress_with_source_security_group_id = [
     {
       rule                     = "all-all"
-      source_security_group_id = module.alb_security_group.this_security_group_id
+      source_security_group_id = module.alb_security_group.security_group_id
     }
   ]
 
@@ -77,7 +77,7 @@ module "alb" {
 
   name               = "${local.prefix}-alb"
   load_balancer_type = "application"
-  security_groups    = [module.alb_security_group.this_security_group_id]
+  security_groups    = [module.alb_security_group.security_group_id]
   subnets            = module.vpc.public_subnets
   vpc_id             = module.vpc.vpc_id
 
@@ -118,7 +118,7 @@ module "easy_fargate" {
   desired_count                = 3
   ignore_desired_count_changes = false
 
-  security_groups  = [module.task_security_group.this_security_group_id]
+  security_groups  = [module.task_security_group.security_group_id]
   vpc_subnets      = module.vpc.public_subnets
   assign_public_ip = true
 

--- a/examples/easy/fargate-spot/README.md
+++ b/examples/easy/fargate-spot/README.md
@@ -43,7 +43,7 @@ $ terraform apply
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.74.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.42.0 |
 
 ## Modules
 
@@ -51,8 +51,8 @@ $ terraform apply
 |------|--------|---------|
 | <a name="module_easy_fargate"></a> [easy\_fargate](#module\_easy\_fargate) | ../../../modules/simple/fargate-spot | n/a |
 | <a name="module_ecs_cluster"></a> [ecs\_cluster](#module\_ecs\_cluster) | ../../.. | n/a |
-| <a name="module_task_security_group"></a> [task\_security\_group](#module\_task\_security\_group) | terraform-aws-modules/security-group/aws | 3.2.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 2.18.0 |
+| <a name="module_task_security_group"></a> [task\_security\_group](#module\_task\_security\_group) | terraform-aws-modules/security-group/aws | ~> 4.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 2 |
 
 ## Resources
 

--- a/examples/easy/fargate-spot/README.md
+++ b/examples/easy/fargate-spot/README.md
@@ -43,7 +43,7 @@ $ terraform apply
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.42.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.74.0 |
 
 ## Modules
 

--- a/examples/easy/fargate-spot/main.tf
+++ b/examples/easy/fargate-spot/main.tf
@@ -11,7 +11,7 @@ locals {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "2.18.0"
+  version = "~> 2"
 
   name = "${local.prefix}-vpc"
   cidr = local.vpc_cidr
@@ -31,7 +31,7 @@ module "vpc" {
 
 module "task_security_group" {
   source  = "terraform-aws-modules/security-group/aws"
-  version = "3.2.0"
+  version = "~> 4.0"
 
   name   = "${local.prefix}-task-sg"
   vpc_id = module.vpc.vpc_id
@@ -66,7 +66,7 @@ module "easy_fargate" {
   ignore_desired_count_changes = false
   num_of_task_on_demand        = 1
 
-  security_groups  = [module.task_security_group.this_security_group_id]
+  security_groups  = [module.task_security_group.security_group_id]
   vpc_subnets      = module.vpc.public_subnets
   assign_public_ip = true
 

--- a/examples/easy/fargate/README.md
+++ b/examples/easy/fargate/README.md
@@ -36,7 +36,7 @@ $ terraform apply
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.42.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.74.0 |
 
 ## Modules
 

--- a/examples/easy/fargate/README.md
+++ b/examples/easy/fargate/README.md
@@ -36,7 +36,7 @@ $ terraform apply
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.74.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.42.0 |
 
 ## Modules
 
@@ -44,8 +44,8 @@ $ terraform apply
 |------|--------|---------|
 | <a name="module_easy_fargate"></a> [easy\_fargate](#module\_easy\_fargate) | ../../../modules/simple/fargate | n/a |
 | <a name="module_ecs_cluster"></a> [ecs\_cluster](#module\_ecs\_cluster) | ../../.. | n/a |
-| <a name="module_task_security_group"></a> [task\_security\_group](#module\_task\_security\_group) | terraform-aws-modules/security-group/aws | 3.2.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 2.18.0 |
+| <a name="module_task_security_group"></a> [task\_security\_group](#module\_task\_security\_group) | terraform-aws-modules/security-group/aws | ~> 4.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 2 |
 
 ## Resources
 

--- a/examples/easy/fargate/main.tf
+++ b/examples/easy/fargate/main.tf
@@ -11,7 +11,7 @@ locals {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "2.18.0"
+  version = "~> 2"
 
   name = "${local.prefix}-vpc"
   cidr = local.vpc_cidr
@@ -31,7 +31,7 @@ module "vpc" {
 
 module "task_security_group" {
   source  = "terraform-aws-modules/security-group/aws"
-  version = "3.2.0"
+  version = "~> 4.0"
 
   name   = "${local.prefix}-task-sg"
   vpc_id = module.vpc.vpc_id
@@ -65,7 +65,7 @@ module "easy_fargate" {
   desired_count                = 1
   ignore_desired_count_changes = false
 
-  security_groups  = [module.task_security_group.this_security_group_id]
+  security_groups  = [module.task_security_group.security_group_id]
   vpc_subnets      = module.vpc.public_subnets
   assign_public_ip = true
 


### PR DESCRIPTION
Examples are not working when tried, terraform validate could not catch it, problem happened during terraform apply phase

Fix by updating the security groups