### PR TITLE
Fix invalid dynamic value if capacity provider strategy not set

### DIFF
--- a/modules/scheduled-actions/README.md
+++ b/modules/scheduled-actions/README.md
@@ -99,7 +99,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_capacity_provider_strategy"></a> [capacity\_provider\_strategy](#input\_capacity\_provider\_strategy) | List of map of capacity provider strategies to use for the task. See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target#capacity_provider_strategy | `list(any)` | `null` | no |
+| <a name="input_capacity_provider_strategy"></a> [capacity\_provider\_strategy](#input\_capacity\_provider\_strategy) | List of map of capacity provider strategies to use for the task. See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target#capacity_provider_strategy | `list(any)` | `[]` | no |
 | <a name="input_cluster_arn"></a> [cluster\_arn](#input\_cluster\_arn) | ECS Cluster ARN to run ECS Task in | `string` | n/a | yes |
 | <a name="input_container_overrides"></a> [container\_overrides](#input\_container\_overrides) | Overrides options of container. Expecting JSON. See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target#ecs-run-task-with-role-and-task-override-usage | `string` | `null` | no |
 | <a name="input_fargate_assign_public_ip"></a> [fargate\_assign\_public\_ip](#input\_fargate\_assign\_public\_ip) | Assign Public IP or not to Fargate task, specify if `is_fargate` | `bool` | `false` | no |

--- a/modules/scheduled-actions/main.tf
+++ b/modules/scheduled-actions/main.tf
@@ -12,7 +12,7 @@ resource "aws_cloudwatch_event_target" "target" {
   ecs_target {
     task_count          = var.task_count
     task_definition_arn = var.task_definition_arn
-    launch_type         = var.capacity_provider_strategy == null ? (var.is_fargate ? "FARGATE" : "EC2") : null
+    launch_type         = length(var.capacity_provider_strategy) == 0 ? (var.is_fargate ? "FARGATE" : "EC2") : null
 
     dynamic "network_configuration" {
       for_each = var.is_fargate ? ["yes"] : []

--- a/modules/scheduled-actions/variables.tf
+++ b/modules/scheduled-actions/variables.tf
@@ -66,6 +66,6 @@ variable "container_overrides" {
 
 variable "capacity_provider_strategy" {
   description = "List of map of capacity provider strategies to use for the task. See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target#capacity_provider_strategy"
-  default     = null
+  default     = []
   type        = list(any)
 }


### PR DESCRIPTION
If `capacity_provider_strategy` is null, `Error: Invalid dynamic for_each value. Cannot use a null value in for_each.` will occur. 
This fix checks if `capacity_provider_strategy` is null and returns an empty list.
I tried changing the variable default to empty string but it will need updating `launch_type` part too.