### PR TITLE
Add ignore_capacity_changes to autoscaling target

### DIFF
--- a/modules/core/ecs-autoscaling-target/README.md
+++ b/modules/core/ecs-autoscaling-target/README.md
@@ -72,6 +72,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_appautoscaling_target.ecs_target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_target) | resource |
+| [aws_appautoscaling_target.ecs_target_ignore_capacity_changes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_target) | resource |
 
 ## Inputs
 
@@ -79,6 +80,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_ecs_cluster_name"></a> [ecs\_cluster\_name](#input\_ecs\_cluster\_name) | ECS Cluster name to apply on (NOT ARN) | `string` | n/a | yes |
 | <a name="input_ecs_service_name"></a> [ecs\_service\_name](#input\_ecs\_service\_name) | ECS Service name to apply on (NOT ARN) | `string` | n/a | yes |
+| <a name="input_ignore_capacity_changes"></a> [ignore\_capacity\_changes](#input\_ignore\_capacity\_changes) | Ignores any changes to `min_capacity` and `max_capacity` parameter after apply. Note updating this value will destroy the existing autoscaling target and recreate it. | `bool` | `false` | no |
 | <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | Maximum capacity of ECS autoscaling target, cannot be less than min\_capacity | `number` | n/a | yes |
 | <a name="input_min_capacity"></a> [min\_capacity](#input\_min\_capacity) | Minimum capacity of ECS autoscaling target, cannot be more than max\_capacity | `number` | n/a | yes |
 

--- a/modules/core/ecs-autoscaling-target/main.tf
+++ b/modules/core/ecs-autoscaling-target/main.tf
@@ -1,4 +1,20 @@
 resource "aws_appautoscaling_target" "ecs_target" {
+  count = var.ignore_capacity_changes ? 0 : 1
+
+  min_capacity       = var.min_capacity
+  max_capacity       = var.max_capacity
+  resource_id        = "service/${var.ecs_cluster_name}/${var.ecs_service_name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+resource "aws_appautoscaling_target" "ecs_target_ignore_capacity_changes" {
+  count = var.ignore_capacity_changes ? 1 : 0
+
+  lifecycle {
+    ignore_changes = [min_capacity, max_capacity]
+  }
+
   min_capacity       = var.min_capacity
   max_capacity       = var.max_capacity
   resource_id        = "service/${var.ecs_cluster_name}/${var.ecs_service_name}"

--- a/modules/core/ecs-autoscaling-target/outputs.tf
+++ b/modules/core/ecs-autoscaling-target/outputs.tf
@@ -1,24 +1,32 @@
+locals {
+  output_resource_id        = concat(aws_appautoscaling_target.ecs_target[*].resource_id, aws_appautoscaling_target.ecs_target_ignore_capacity_changes[*].resource_id, [""])[0]
+  output_service_namespace  = concat(aws_appautoscaling_target.ecs_target[*].service_namespace, aws_appautoscaling_target.ecs_target_ignore_capacity_changes[*].service_namespace, [""])[0]
+  output_scalable_dimension = concat(aws_appautoscaling_target.ecs_target[*].scalable_dimension, aws_appautoscaling_target.ecs_target_ignore_capacity_changes[*].scalable_dimension, [""])[0]
+  output_min_capacity       = concat(aws_appautoscaling_target.ecs_target[*].min_capacity, aws_appautoscaling_target.ecs_target_ignore_capacity_changes[*].min_capacity, [""])[0]
+  output_max_capacity       = concat(aws_appautoscaling_target.ecs_target[*].max_capacity, aws_appautoscaling_target.ecs_target_ignore_capacity_changes[*].max_capacity, [""])[0]
+}
+
 output "resource_id" {
   description = "Resources ID of the created Autoscaling Target for ECS Service, used in policy/schedule"
-  value       = aws_appautoscaling_target.ecs_target.resource_id
+  value       = local.output_resource_id
 }
 
 output "service_namespace" {
   description = "Service namespace for autoscaling target. Always ecs"
-  value       = aws_appautoscaling_target.ecs_target.service_namespace
+  value       = local.output_service_namespace
 }
 
 output "scalable_dimension" {
   description = "Scalable dimension for autoscaling target. Always ecs:service:DesiredCount."
-  value       = aws_appautoscaling_target.ecs_target.scalable_dimension
+  value       = local.output_scalable_dimension
 }
 
 output "min_capacity" {
   description = "Minimum capacity for autoscaling target, same value as inputted"
-  value       = aws_appautoscaling_target.ecs_target.min_capacity
+  value       = local.output_min_capacity
 }
 
 output "max_capacity" {
   description = "Maximum capacity for autoscaling target, same value as inputted"
-  value       = aws_appautoscaling_target.ecs_target.max_capacity
+  value       = local.output_max_capacity
 }

--- a/modules/core/ecs-autoscaling-target/variables.tf
+++ b/modules/core/ecs-autoscaling-target/variables.tf
@@ -17,3 +17,9 @@ variable "max_capacity" {
   description = "Maximum capacity of ECS autoscaling target, cannot be less than min_capacity"
   type        = number
 }
+
+variable "ignore_capacity_changes" {
+  description = "Ignores any changes to `min_capacity` and `max_capacity` parameter after apply. Note updating this value will destroy the existing autoscaling target and recreate it."
+  default     = false
+  type        = bool
+}


### PR DESCRIPTION
~Need to bump minor version (or maybe major?), since this will remove and recreate the autoscaling target.~
Actually it's fine, terraform automatically move the resource to the new one with count, without recreating the resource.

Tested on shobo-renovate.