### PR TITLE
Add example to use EC2 instance managed draining

### DIFF
--- a/examples/easy/ec2-managed-draining/README.md
+++ b/examples/easy/ec2-managed-draining/README.md
@@ -1,7 +1,7 @@
 # examples/easy/ec2-managed-draining
 
 In this example we'll instantiate a simple nginx webserver, running on EC2 Auto Scaling Group, with managed draining feature enabled.
-This means ECS will monitor the Auto Scaling Group and set an instance status to draining when it's scheduled for termination.
+This means ECS will monitor the Auto Scaling Group and set an instance's status to draining when it's scheduled for termination.
 With draining status set, ECS will safely terminate all tasks running on the instance and create replacement tasks in other instance(s).
 
 Note: Instance profile is required for EC2 to connect to ECS Cluster. See [`modules/iam/ecs-instance-profile`](https://github.com/HENNGE/terraform-aws-ecs/tree/main/modules/iam/ecs-instance-profile).

--- a/examples/easy/ec2-managed-draining/README.md
+++ b/examples/easy/ec2-managed-draining/README.md
@@ -1,0 +1,70 @@
+# examples/easy/ec2
+
+In this example we'll instantiate a simple nginx webserver.
+
+Task networking mode in this example is `host` so that the port specified in `templates/container_definitions.tpl` will be bind.
+Means there cannot be more than 1 task in an instance. Do experiment with dynamic port mapping with `bridge` network mode.
+
+This example will also create `vpc` and `security_group` and `autoscaling group`.
+
+Note: Instance profile is required for EC2 to connect to ECS Cluster. See [`modules/iam/ecs-instance-profile`](https://github.com/HENNGE/terraform-aws-ecs/tree/main/modules/iam/ecs-instance-profile).
+
+To test that it's working:
+1. Go to EC2 console
+1. Find the EC2 instance started by this example. (Search the name)
+1. Go to the IP Address, you should see nginx hello world screen
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.74.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.74.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_asg"></a> [asg](#module\_asg) | terraform-aws-modules/autoscaling/aws | ~> 7.0 |
+| <a name="module_easy_ec2"></a> [easy\_ec2](#module\_easy\_ec2) | ../../../modules/simple/ec2 | n/a |
+| <a name="module_ec2_security_group"></a> [ec2\_security\_group](#module\_ec2\_security\_group) | terraform-aws-modules/security-group/aws | ~> 4.0 |
+| <a name="module_ecs_cluster"></a> [ecs\_cluster](#module\_ecs\_cluster) | ../../.. | n/a |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+| [aws_ssm_parameter.ami_image](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | Override automatic detection of availability zones | `list(string)` | `[]` | no |
+| <a name="input_enable_ipv6"></a> [enable\_ipv6](#input\_enable\_ipv6) | Enable IPv6? | `bool` | `true` | no |
+| <a name="input_instance_profile_arn"></a> [instance\_profile\_arn](#input\_instance\_profile\_arn) | Instance Profile to use for EC2 to join to ECS Cluster. See `modules/iam/ecs-instance-profile` | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/easy/ec2-managed-draining/README.md
+++ b/examples/easy/ec2-managed-draining/README.md
@@ -1,11 +1,8 @@
-# examples/easy/ec2
+# examples/easy/ec2-managed-draining
 
-In this example we'll instantiate a simple nginx webserver.
-
-Task networking mode in this example is `host` so that the port specified in `templates/container_definitions.tpl` will be bind.
-Means there cannot be more than 1 task in an instance. Do experiment with dynamic port mapping with `bridge` network mode.
-
-This example will also create `vpc` and `security_group` and `autoscaling group`.
+In this example we'll instantiate a simple nginx webserver, running on EC2 Auto Scaling Group, with managed draining feature enabled.
+This means ECS will monitor the Auto Scaling Group and set an instance status to draining when it's scheduled for termination.
+With draining status set, ECS will safely terminate all tasks running on the instance and create replacement tasks in other instance(s).
 
 Note: Instance profile is required for EC2 to connect to ECS Cluster. See [`modules/iam/ecs-instance-profile`](https://github.com/HENNGE/terraform-aws-ecs/tree/main/modules/iam/ecs-instance-profile).
 
@@ -53,6 +50,7 @@ $ terraform apply
 
 | Name | Type |
 |------|------|
+| [aws_ecs_capacity_provider.asg_managed_draining](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_capacity_provider) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_ssm_parameter.ami_image](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 

--- a/examples/easy/ec2-managed-draining/main.tf
+++ b/examples/easy/ec2-managed-draining/main.tf
@@ -1,0 +1,116 @@
+# Just Supporting Infrastructures
+
+data "aws_availability_zones" "available" {}
+
+data "aws_ssm_parameter" "ami_image" {
+  name = "/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id"
+}
+
+locals {
+  prefix = "easy-ec2"
+
+  vpc_cidr       = "10.0.0.0/16"
+  discovered_azs = data.aws_availability_zones.available.names
+  vpc_azs        = length(var.availability_zones) == 0 ? local.discovered_azs : var.availability_zones
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.0"
+
+  name = "${local.prefix}-vpc"
+  cidr = local.vpc_cidr
+  azs  = local.vpc_azs
+
+  public_subnets = [for i in range(length(local.vpc_azs)) : cidrsubnet(local.vpc_cidr, 8, i)]
+
+  enable_nat_gateway               = false
+  enable_dhcp_options              = true
+  dhcp_options_domain_name_servers = ["AmazonProvidedDNS"]
+
+  map_public_ip_on_launch = true
+
+  enable_ipv6                                   = var.enable_ipv6
+  public_subnet_assign_ipv6_address_on_creation = var.enable_ipv6
+  public_subnet_ipv6_prefixes                   = range(length(local.vpc_azs))
+}
+
+module "ec2_security_group" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 4.0"
+
+  name   = "${local.prefix}-ec2-sg"
+  vpc_id = module.vpc.vpc_id
+
+
+  # Ingress for HTTP
+  ingress_cidr_blocks      = ["0.0.0.0/0"]
+  ingress_ipv6_cidr_blocks = ["::/0"]
+  ingress_rules            = ["http-80-tcp"]
+
+  # Allow all egress
+  egress_cidr_blocks      = ["0.0.0.0/0"]
+  egress_ipv6_cidr_blocks = ["::/0"]
+  egress_rules            = ["all-all"]
+}
+
+module "asg" {
+  source  = "terraform-aws-modules/autoscaling/aws"
+  version = "~> 7.0"
+
+  name = "${local.prefix}-asg"
+
+  image_id            = data.aws_ssm_parameter.ami_image.value
+  instance_type       = "t2.micro"
+  security_groups     = [module.ec2_security_group.security_group_id]
+  vpc_zone_identifier = module.vpc.public_subnets
+  min_size            = 1
+  max_size            = 2
+  desired_capacity    = 1
+  health_check_type   = "EC2"
+  user_data = base64encode(templatefile("../../templates/ec2_userdata.tpl", {
+    ecs_cluster = module.ecs_cluster.name
+  }))
+  iam_instance_profile_arn = var.instance_profile_arn
+
+  tags = {
+    AmazonECSManaged = "true"
+  }
+}
+
+resource "aws_ecs_capacity_provider" "asg_managed_draining" {
+  name = "${local.prefix}-capacity-provider-asg-managed-draining"
+
+  auto_scaling_group_provider {
+    auto_scaling_group_arn = module.asg.autoscaling_group_arn
+    managed_draining       = "ENABLED"
+  }
+}
+
+# This module usage starts here
+module "ecs_cluster" {
+  source = "../../.."
+
+  name = "${local.prefix}-cluster"
+
+  capacity_providers = [aws_ecs_capacity_provider.asg_managed_draining.name]
+}
+
+module "easy_ec2" {
+  source = "../../../modules/simple/ec2"
+
+  name                         = "${local.prefix}-service"
+  cluster                      = module.ecs_cluster.name
+  cpu                          = 256
+  memory                       = 512
+  desired_count                = 1
+  ignore_desired_count_changes = false
+
+  network_mode = "host"
+
+  container_definitions = templatefile("../../templates/container_definitions.tpl", {
+    name   = "${local.prefix}-cont"
+    cpu    = 256
+    memory = 512
+  })
+}

--- a/examples/easy/ec2-managed-draining/main.tf
+++ b/examples/easy/ec2-managed-draining/main.tf
@@ -79,7 +79,7 @@ module "asg" {
 }
 
 resource "aws_ecs_capacity_provider" "asg_managed_draining" {
-  name = "${local.prefix}-capacity-provider-asg-managed-draining"
+  name = "${local.prefix}-capacity-provider"
 
   auto_scaling_group_provider {
     auto_scaling_group_arn = module.asg.autoscaling_group_arn

--- a/examples/easy/ec2-managed-draining/variables.tf
+++ b/examples/easy/ec2-managed-draining/variables.tf
@@ -1,0 +1,16 @@
+variable "instance_profile_arn" {
+  description = "Instance Profile to use for EC2 to join to ECS Cluster. See `modules/iam/ecs-instance-profile`"
+  type        = string
+}
+
+variable "availability_zones" {
+  description = "Override automatic detection of availability zones"
+  default     = []
+  type        = list(string)
+}
+
+variable "enable_ipv6" {
+  description = "Enable IPv6?"
+  default     = true
+  type        = bool
+}

--- a/examples/easy/ec2-managed-draining/versions.tf
+++ b/examples/easy/ec2-managed-draining/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.74.0"
+    }
+  }
+}


### PR DESCRIPTION
Resolves #29

Since the cluster module already accepts a list of capacity providers, there's no need to include the capacity provider resource into the module.
Including it will also complicate the cluster module input, since capacity provider can be used for myriad other features, not just managed draining.