### PR TITLE
Fix aws_appautoscaling_target default tags tf plan pollution

### DIFF
--- a/modules/core/ecs-autoscaling-target/main.tf
+++ b/modules/core/ecs-autoscaling-target/main.tf
@@ -1,6 +1,11 @@
 resource "aws_appautoscaling_target" "ecs_target" {
   count = var.ignore_capacity_changes ? 0 : 1
 
+  # Workaround for https://github.com/hashicorp/terraform-provider-aws/issues/31261
+  lifecycle {
+    ignore_changes = [tags_all]
+  }
+
   min_capacity       = var.min_capacity
   max_capacity       = var.max_capacity
   resource_id        = "service/${var.ecs_cluster_name}/${var.ecs_service_name}"
@@ -11,8 +16,9 @@ resource "aws_appautoscaling_target" "ecs_target" {
 resource "aws_appautoscaling_target" "ecs_target_ignore_capacity_changes" {
   count = var.ignore_capacity_changes ? 1 : 0
 
+  # Workaround for https://github.com/hashicorp/terraform-provider-aws/issues/31261
   lifecycle {
-    ignore_changes = [min_capacity, max_capacity]
+    ignore_changes = [min_capacity, max_capacity, tags_all]
   }
 
   min_capacity       = var.min_capacity


### PR DESCRIPTION
As explained in this issue: https://github.com/hashicorp/terraform-provider-aws/issues/31261,
old aws_appautoscaling_target (created before 2023-03-20) can not have any tags or default tags,
otherwise it will perpetually show up in tf plan.

This implement a workaround by ignoring tags_all that may have been set in the provider default tags.