### PR TITLE
Allow passing of `network_configuration` to schedule

### DIFF
--- a/modules/core/task/README.md
+++ b/modules/core/task/README.md
@@ -10,14 +10,14 @@ Almost a 1-1 mapping to `resources`.
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.85.0 |
 
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.85.0 |
 
 ## Modules
@@ -27,13 +27,13 @@ No modules.
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [aws_ecs_task_definition.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_container_definitions"></a> [container\_definitions](#input\_container\_definitions) | Container definitions raw json string or rendered template. | `string` | n/a | yes |
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | CPU unit for this task. | `number` | `null` | no |
 | <a name="input_create_task_definition"></a> [create\_task\_definition](#input\_create\_task\_definition) | Create the Task Definition | `bool` | `true` | no |
@@ -58,7 +58,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | Full ARN of the Task Definition (including both `family` and `revision`). |
 | <a name="output_name"></a> [name](#output\_name) | The created task definition name |
 | <a name="output_revision"></a> [revision](#output\_revision) | The revision number of the task definition |

--- a/modules/core/task/README.md
+++ b/modules/core/task/README.md
@@ -10,14 +10,14 @@ Almost a 1-1 mapping to `resources`.
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.85.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.85.0 |
 
 ## Modules
@@ -27,13 +27,13 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_ecs_task_definition.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_container_definitions"></a> [container\_definitions](#input\_container\_definitions) | Container definitions raw json string or rendered template. | `string` | n/a | yes |
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | CPU unit for this task. | `number` | `null` | no |
 | <a name="input_create_task_definition"></a> [create\_task\_definition](#input\_create\_task\_definition) | Create the Task Definition | `bool` | `true` | no |
@@ -58,7 +58,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_arn"></a> [arn](#output\_arn) | Full ARN of the Task Definition (including both `family` and `revision`). |
 | <a name="output_name"></a> [name](#output\_name) | The created task definition name |
 | <a name="output_revision"></a> [revision](#output\_revision) | The revision number of the task definition |

--- a/modules/core/task/variables.tf
+++ b/modules/core/task/variables.tf
@@ -1,6 +1,6 @@
-/**
- * Required Variables.
- */
+####################
+# Required Variables
+####################
 
 variable "name" {
   description = "The task name."
@@ -12,9 +12,9 @@ variable "container_definitions" {
   type        = string
 }
 
-/**
- * Optional Variables.
- */
+####################
+# Optional Variables
+####################
 
 variable "create_task_definition" {
   description = "Create the Task Definition"

--- a/modules/scheduled-actions/README.md
+++ b/modules/scheduled-actions/README.md
@@ -70,6 +70,36 @@ module "ecs_fargate_cron" {
 }
 ```
 
+### Managed Instances Launch Type
+
+Use `capacity_provider_strategy` instead of a launch type, and `network_configuration` for the
+`awsvpc` network mode that Managed Instances requires.
+
+```hcl
+module "ecs_managed_instances_cron" {
+  source  = "HENNGE/ecs/aws//modules/scheduled-actions"
+  version = "1.0.0"
+
+  name                 = "worker-managed-cron"
+  schedule_description = "Run this daily"
+  schedule_rule        = "cron(0 9 * * ? *)"
+  cluster_arn          = module.ecs_cluster.arn
+  iam_invoker          = var.iam_invoker
+  task_count           = 1
+  task_definition_arn  = module.ecs_service.task_definition_arn
+
+  capacity_provider_strategy = [{
+    capacity_provider = aws_ecs_capacity_provider.managed_instances.name
+    weight            = 1
+  }]
+
+  network_configuration = {
+    subnets         = module.vpc.private_subnets
+    security_groups = [module.instance_security_group.this_security_group_id]
+  }
+}
+```
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -102,12 +132,13 @@ No modules.
 | <a name="input_capacity_provider_strategy"></a> [capacity\_provider\_strategy](#input\_capacity\_provider\_strategy) | List of map of capacity provider strategies to use for the task. See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target#capacity_provider_strategy | `list(any)` | `[]` | no |
 | <a name="input_cluster_arn"></a> [cluster\_arn](#input\_cluster\_arn) | ECS Cluster ARN to run ECS Task in | `string` | n/a | yes |
 | <a name="input_container_overrides"></a> [container\_overrides](#input\_container\_overrides) | Overrides options of container. Expecting JSON. See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target#ecs-run-task-with-role-and-task-override-usage | `string` | `null` | no |
-| <a name="input_fargate_assign_public_ip"></a> [fargate\_assign\_public\_ip](#input\_fargate\_assign\_public\_ip) | Assign Public IP or not to Fargate task, specify if `is_fargate` | `bool` | `false` | no |
-| <a name="input_fargate_security_groups"></a> [fargate\_security\_groups](#input\_fargate\_security\_groups) | Security groups to assign to Fargate task, specify if `is_fargate` | `list(string)` | `[]` | no |
-| <a name="input_fargate_subnets"></a> [fargate\_subnets](#input\_fargate\_subnets) | Subnets to assign to Fargate task, specify if `is_fargate` | `list(string)` | `[]` | no |
+| <a name="input_fargate_assign_public_ip"></a> [fargate\_assign\_public\_ip](#input\_fargate\_assign\_public\_ip) | Assign Public IP or not to Fargate task, specify if `is_fargate`. Deprecated: use `network_configuration.assign_public_ip`. | `bool` | `false` | no |
+| <a name="input_fargate_security_groups"></a> [fargate\_security\_groups](#input\_fargate\_security\_groups) | Security groups to assign to Fargate task, specify if `is_fargate`. Deprecated: use `network_configuration.security_groups`. | `list(string)` | `[]` | no |
+| <a name="input_fargate_subnets"></a> [fargate\_subnets](#input\_fargate\_subnets) | Subnets to assign to Fargate task, specify if `is_fargate`. Deprecated: use `network_configuration.subnets`. | `list(string)` | `[]` | no |
 | <a name="input_iam_invoker"></a> [iam\_invoker](#input\_iam\_invoker) | IAM ARN to invoke ECS Task | `string` | n/a | yes |
-| <a name="input_is_fargate"></a> [is\_fargate](#input\_is\_fargate) | Task is fargate | `bool` | `false` | no |
+| <a name="input_is_fargate"></a> [is\_fargate](#input\_is\_fargate) | Task is fargate. Only affects `launch_type`; to attach a network configuration to a non-Fargate `awsvpc` task, use `network_configuration` instead. | `bool` | `false` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name for scheduled action | `string` | n/a | yes |
+| <a name="input_network_configuration"></a> [network\_configuration](#input\_network\_configuration) | Network configuration for tasks that use the `awsvpc` network mode. Required by RunTask for `awsvpc` under any launch type, not just Fargate. Takes precedence over the `fargate_*` variables. Must be null when the task does not use `awsvpc`, otherwise the task fails. | <pre>object({<br/>    subnets          = list(string)<br/>    security_groups  = optional(list(string), [])<br/>    assign_public_ip = optional(bool, false)<br/>  })</pre> | `null` | no |
 | <a name="input_propagate_tags"></a> [propagate\_tags](#input\_propagate\_tags) | Specifies whether to propagate the tags from the task definition to the task. | `bool` | `false` | no |
 | <a name="input_schedule_description"></a> [schedule\_description](#input\_schedule\_description) | The description of the rule | `string` | `"Cloudwatch event rule to invoke ECS Task"` | no |
 | <a name="input_schedule_rule"></a> [schedule\_rule](#input\_schedule\_rule) | Schedule in cron or rate (see: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html for rules) | `string` | n/a | yes |

--- a/modules/scheduled-actions/README.md
+++ b/modules/scheduled-actions/README.md
@@ -78,7 +78,7 @@ Use `capacity_provider_strategy` instead of a launch type, and `network_configur
 ```hcl
 module "ecs_managed_instances_cron" {
   source  = "HENNGE/ecs/aws//modules/scheduled-actions"
-  version = "1.0.0"
+  version = "5.6.0"
 
   name                 = "worker-managed-cron"
   schedule_description = "Run this daily"

--- a/modules/scheduled-actions/main.tf
+++ b/modules/scheduled-actions/main.tf
@@ -1,3 +1,13 @@
+locals {
+  network_configuration = var.network_configuration != null ? var.network_configuration : (
+    var.is_fargate ? {
+      subnets          = var.fargate_subnets
+      security_groups  = var.fargate_security_groups
+      assign_public_ip = var.fargate_assign_public_ip
+    } : null
+  )
+}
+
 resource "aws_cloudwatch_event_rule" "rule" {
   name                = var.name
   description         = var.schedule_description
@@ -15,11 +25,11 @@ resource "aws_cloudwatch_event_target" "target" {
     launch_type         = length(var.capacity_provider_strategy) == 0 ? (var.is_fargate ? "FARGATE" : "EC2") : null
 
     dynamic "network_configuration" {
-      for_each = var.is_fargate ? ["yes"] : []
+      for_each = local.network_configuration == null ? [] : [local.network_configuration]
       content {
-        subnets          = var.fargate_subnets
-        security_groups  = var.fargate_security_groups
-        assign_public_ip = var.fargate_assign_public_ip
+        subnets          = network_configuration.value.subnets
+        security_groups  = network_configuration.value.security_groups
+        assign_public_ip = network_configuration.value.assign_public_ip
       }
     }
 

--- a/modules/scheduled-actions/variables.tf
+++ b/modules/scheduled-actions/variables.tf
@@ -35,25 +35,35 @@ variable "task_definition_arn" {
 }
 
 variable "is_fargate" {
-  description = "Task is fargate"
+  description = "Task is fargate. Only affects `launch_type`; to attach a network configuration to a non-Fargate `awsvpc` task, use `network_configuration` instead."
   default     = false
   type        = bool
 }
 
+variable "network_configuration" {
+  description = "Network configuration for tasks that use the `awsvpc` network mode. Required by RunTask for `awsvpc` under any launch type, not just Fargate. Takes precedence over the `fargate_*` variables. Must be null when the task does not use `awsvpc`, otherwise the task fails."
+  default     = null
+  type = object({
+    subnets          = list(string)
+    security_groups  = optional(list(string), [])
+    assign_public_ip = optional(bool, false)
+  })
+}
+
 variable "fargate_assign_public_ip" {
-  description = "Assign Public IP or not to Fargate task, specify if `is_fargate`"
+  description = "Assign Public IP or not to Fargate task, specify if `is_fargate`. Deprecated: use `network_configuration.assign_public_ip`."
   default     = false
   type        = bool
 }
 
 variable "fargate_security_groups" {
-  description = "Security groups to assign to Fargate task, specify if `is_fargate`"
+  description = "Security groups to assign to Fargate task, specify if `is_fargate`. Deprecated: use `network_configuration.security_groups`."
   default     = []
   type        = list(string)
 }
 
 variable "fargate_subnets" {
-  description = "Subnets to assign to Fargate task, specify if `is_fargate`"
+  description = "Subnets to assign to Fargate task, specify if `is_fargate`. Deprecated: use `network_configuration.subnets`."
   default     = []
   type        = list(string)
 }


### PR DESCRIPTION
ref: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target#network_configuration-1

Allows for the passing of network configuration independently of `is_fargate = true`. This allows for the expression of a managed instance target using `awsvpc` network mode. Retains backwards compatibility for those using the fargate network inputs. 

