### PR TITLE
docs: explain how to force a redeployment on every apply

### DIFF
--- a/modules/core/service/README.md
+++ b/modules/core/service/README.md
@@ -10,6 +10,29 @@ The goal of this module is to present a unified view between `ECS Service` and `
 
 Since this module is the closest to the `resources` form, there are a lot of customization, for those who want it easy, do check the `simple` module instead of this `core` module.
 
+## Forcing a redeployment on every `apply`
+
+Setting `force_new_deployment = true` on its own does not force a new
+deployment on every `terraform apply` — once the value stops changing
+between runs, Terraform sees no diff on that attribute and skips the
+redeploy (see [hashicorp/terraform-provider-aws#13528](https://github.com/hashicorp/terraform-provider-aws/issues/13528)).
+To force a redeployment on every apply regardless of whether anything else
+changed, combine it with `triggers` and a value that changes every plan,
+such as [`plantimestamp()`](https://developer.hashicorp.com/terraform/language/functions/plantimestamp):
+
+```hcl
+module "service" {
+  source = "HENNGE/ecs/aws//modules/core/service"
+
+  force_new_deployment = true
+  triggers = {
+    redeployment = plantimestamp()
+  }
+
+  # ...
+}
+```
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/modules/simple/fargate/README.md
+++ b/modules/simple/fargate/README.md
@@ -14,6 +14,29 @@ Creates the following:
 - ECS Service
 - ECS Task Definition
 
+## Forcing a redeployment on every `apply`
+
+Setting `force_new_deployment = true` on its own does not force a new
+deployment on every `terraform apply` — once the value stops changing
+between runs, Terraform sees no diff on that attribute and skips the
+redeploy (see [hashicorp/terraform-provider-aws#13528](https://github.com/hashicorp/terraform-provider-aws/issues/13528)).
+To force a redeployment on every apply regardless of whether anything else
+changed, combine it with `triggers` and a value that changes every plan,
+such as [`plantimestamp()`](https://developer.hashicorp.com/terraform/language/functions/plantimestamp):
+
+```hcl
+module "fargate" {
+  source = "HENNGE/ecs/aws//modules/simple/fargate"
+
+  force_new_deployment = true
+  triggers = {
+    redeployment = plantimestamp()
+  }
+
+  # ...
+}
+```
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 


### PR DESCRIPTION
## Summary

Closes #43.

`force_new_deployment = true` on its own does not force a new ECS deployment on every `terraform apply` — Terraform's AWS provider only triggers the redeploy when that attribute's *value changes* between runs, so once it's statically `true` in HCL, later applies with no other changes are reported as "No changes. Infrastructure is up-to-date." (see [hashicorp/terraform-provider-aws#13528](https://github.com/hashicorp/terraform-provider-aws/issues/13528), which #43 also links).

The module already exposes exactly the mechanism that solves this — a `triggers` map that passes straight through to the underlying `aws_ecs_service` resource — but neither `modules/simple/fargate/README.md` nor `modules/core/service/README.md` explained that combining `force_new_deployment` with `triggers` (e.g. `plantimestamp()`) is what actually reproduces the "force" behavior users expect. The `triggers` input's own one-line description mentions `plantimestamp()` but doesn't connect it back to the `force_new_deployment` problem.

This adds a short "Forcing a redeployment on every apply" section with a working example to both READMEs, placed above each file's `<!-- BEGIN_TF_DOCS -->` marker so it doesn't collide with `terraform-docs` generation. Docs only — no `.tf` changes, so `terraform_docs`/`terraform_fmt`/`terraform_validate`/`tflint` pre-commit hooks are unaffected.

## Test plan

- [x] Read `modules/core/service/main.tf` to confirm `triggers` is wired through to the `aws_ecs_service` resource's `triggers` argument, and that this is the documented Terraform-level fix for the exact symptom in #43.
- [x] Confirmed neither README already covered this combination.
- [x] Verified both edited files still end with a single trailing newline and the new section sits entirely above `<!-- BEGIN_TF_DOCS -->` in each file, so `terraform-docs` regeneration produces no diff.
- N/A automated tests — documentation-only change, no resources/variables modified.